### PR TITLE
feat: challenge leaderboard colour dots + Android challenge widget

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -148,6 +148,31 @@
                 android:resource="@xml/hr_zone_widget_info" />
         </receiver>
 
+        <!-- Challenge Widget: race chart + leaderboard of one chosen challenge -->
+        <receiver
+            android:name=".widget.ChallengeWidgetProvider"
+            android:exported="true"
+            android:label="@string/challenge_widget_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="net.aurboda.ACTION_UPDATE_CHALLENGE_WIDGETS" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/challenge_widget_info" />
+        </receiver>
+
+        <!-- Picks which challenge a newly placed challenge widget follows -->
+        <activity
+            android:name=".widget.ChallengeWidgetConfigActivity"
+            android:exported="true"
+            android:label="@string/challenge_widget_name"
+            android:theme="@style/Theme.Aurboda">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
         <!-- Widget RemoteViews Service for scrollable goals list -->
         <service
             android:name=".widget.GoalsWidgetService"

--- a/apps/android/app/src/main/java/net/aurboda/AppState.kt
+++ b/apps/android/app/src/main/java/net/aurboda/AppState.kt
@@ -22,6 +22,25 @@ enum class MainTab {
     More
 }
 
+/**
+ * Where a widget or notification tap asks the app to go: a tab, and for the More
+ * tab optionally the web page to push (a site path like "/goals", or an absolute
+ * URL for a page on another instance).
+ */
+data class DeepLink(val tab: MainTab, val morePath: String? = null)
+
+/** Decode the [MainActivity.EXTRA_OPEN_TAB] / [MainActivity.EXTRA_MORE_PATH] extras; null when there is no link. */
+fun deepLinkFrom(openTab: String?, morePath: String?): DeepLink? {
+    val tab =
+        when (openTab) {
+            MainActivity.TAB_ADD -> MainTab.Add
+            MainActivity.TAB_FEED -> MainTab.Feed
+            MainActivity.TAB_MORE -> MainTab.More
+            else -> return null
+        }
+    return DeepLink(tab, if (tab == MainTab.More) morePath else null)
+}
+
 class AppState(
     private val context: Context,
     initialScreen: AppScreen,
@@ -71,6 +90,12 @@ class AppState(
 
     fun openMoreDestination(destination: MoreDestination) {
         moreDestination = destination
+    }
+
+    /** Follow a deep link that arrived while the app was already running. */
+    fun open(link: DeepLink) {
+        selectTab(link.tab)
+        link.morePath?.let { moreDestination = MoreDestination.Web(it) }
     }
 
     fun closeMoreDestination() {

--- a/apps/android/app/src/main/java/net/aurboda/ChallengeApi.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ChallengeApi.kt
@@ -1,0 +1,118 @@
+package net.aurboda
+
+import android.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import net.aurboda.api.models.Challenge
+import net.aurboda.api.models.ChallengeParticipation
+import net.aurboda.api.models.ChallengeParticipationsResponse
+import net.aurboda.api.models.ChallengeStanding
+import net.aurboda.api.models.ChallengeStandingsResponse
+import net.aurboda.api.models.ChallengesResponse
+import net.aurboda.api.models.WellKnownAurboda
+import java.net.URLEncoder
+
+private const val TAG = "ChallengeApi"
+
+/** A parsed public challenge URL `<base>/u/<username>/<slug>` (base may carry a sub-path). */
+data class ChallengeUrl(val base: String, val username: String, val slug: String)
+
+/**
+ * Parse a challenge (or any `/u/:username/:slug`) URL into its instance base,
+ * host username and slug — the same split the backend's federation code does.
+ * Returns null when the URL doesn't have that shape.
+ */
+fun parseChallengeUrl(url: String): ChallengeUrl? {
+    val marker = "/u/"
+    val i = url.indexOf(marker)
+    if (i < 0) return null
+    val base = url.substring(0, i).trimEnd('/')
+    val parts = url.substring(i + marker.length).split('/').filter { it.isNotEmpty() }
+    if (base.isEmpty() || parts.size < 2) return null
+    return ChallengeUrl(base = base, username = parts[0], slug = parts[1])
+}
+
+/**
+ * The API base for the instance at [instanceBase]. The user's own instance is
+ * answered locally from [credentials]; any other instance is discovered through
+ * its `/.well-known/aurboda` document, exactly like the backend does when joining.
+ */
+suspend fun resolveApiBase(
+    httpClient: HttpClient,
+    credentials: CredentialsManager.Credentials,
+    instanceBase: String,
+): DataResult<String> {
+    if (instanceBase.trimEnd('/') == credentials.serverUrl.trimEnd('/')) {
+        return DataResult.Success(credentials.apiUrl)
+    }
+    return discoverApiBase(httpClient, instanceBase)
+}
+
+/** Discover a (remote) instance's API base from `<base>/.well-known/aurboda`. */
+suspend fun discoverApiBase(httpClient: HttpClient, instanceBase: String): DataResult<String> =
+    when (val res = getJson<WellKnownAurboda>(httpClient, "${instanceBase.trimEnd('/')}/.well-known/aurboda")) {
+        is DataResult.Success ->
+            if (res.data.federation) DataResult.Success(res.data.apiBase)
+            else DataResult.Error("Instance does not support federation")
+        is DataResult.Error -> res
+    }
+
+/** Challenges hosted by the signed-in user. */
+suspend fun fetchChallenges(
+    httpClient: HttpClient,
+    apiUrl: String,
+    authToken: String,
+): DataResult<List<Challenge>> =
+    getJson<ChallengesResponse>(httpClient, "$apiUrl/challenges", authToken).map { it.challenges }
+
+/** Challenges the signed-in user has joined (any status; callers filter). */
+suspend fun fetchChallengeParticipations(
+    httpClient: HttpClient,
+    apiUrl: String,
+    authToken: String,
+): DataResult<List<ChallengeParticipation>> =
+    getJson<ChallengeParticipationsResponse>(httpClient, "$apiUrl/challenges/participations/mine", authToken)
+        .map { it.participations }
+
+/** Public standings of the challenge at `/u/[username]/[slug]` on the instance serving [apiBase]. */
+suspend fun fetchPublicChallengeStandings(
+    httpClient: HttpClient,
+    apiBase: String,
+    username: String,
+    slug: String,
+): DataResult<List<ChallengeStanding>> {
+    val url = "${apiBase.trimEnd('/')}/public/${urlEncode(username)}/${urlEncode(slug)}/standings"
+    return getJson<ChallengeStandingsResponse>(httpClient, url).map { it.members ?: emptyList() }
+}
+
+private fun urlEncode(s: String): String = URLEncoder.encode(s, "UTF-8").replace("+", "%20")
+
+private inline fun <T, R> DataResult<T>.map(f: (T) -> R): DataResult<R> =
+    when (this) {
+        is DataResult.Success -> DataResult.Success(f(data))
+        is DataResult.Error -> this
+    }
+
+private suspend inline fun <reified T> getJson(
+    httpClient: HttpClient,
+    url: String,
+    authToken: String? = null,
+): DataResult<T> =
+    try {
+        val response = httpClient.get(url) {
+            if (authToken != null) headers { append(HttpHeaders.Authorization, "Bearer $authToken") }
+        }
+        if (response.status == HttpStatusCode.OK) {
+            DataResult.Success(appJson.decodeFromString<T>(response.bodyAsText()))
+        } else {
+            Log.e(TAG, "GET $url failed: ${response.status}")
+            DataResult.Error("Server returned ${response.status}")
+        }
+    } catch (e: Exception) {
+        Log.e(TAG, "GET $url threw", e)
+        DataResult.Error(e.message ?: "Unknown error")
+    }

--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -153,27 +153,39 @@ class MainActivity : ComponentActivity() {
     const val EXTRA_MORE_PATH = "more_path"
   }
 
-  // Deep links (widget / notification) only steer the initial screen on a cold
-  // start. The activity is `singleTop`, so when it's already open the launch is
-  // delivered to onNewIntent (not overridden) and the current screen is kept.
+  /**
+   * A deep link delivered while the activity was already running. Wrapped with a
+   * sequence number so tapping the same widget twice re-navigates (a plain
+   * DeepLink would compare equal and not retrigger the effect).
+   */
+  private var runningDeepLink by mutableStateOf<DeepLinkEvent?>(null)
+  private var deepLinkSeq = 0L
+
+  // Deep links (widget / notification) steer the initial screen on a cold start
+  // and, because the activity is `singleTop`, arrive in onNewIntent when the app
+  // is already open — where they navigate the running app to the same place.
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    val openTab = intent?.getStringExtra(EXTRA_OPEN_TAB)
-    val initialTab =
-      when (openTab) {
-        TAB_ADD -> MainTab.Add
-        TAB_FEED -> MainTab.Feed
-        TAB_MORE -> MainTab.More
-        else -> null
-      }
-    val initialMorePath = if (openTab == TAB_MORE) intent?.getStringExtra(EXTRA_MORE_PATH) else null
+    val link = deepLinkFrom(intent)
     setContent {
       AurbodaAppShell {
-        AurbodaApp(initialTab = initialTab, initialMorePath = initialMorePath)
+        AurbodaApp(initialTab = link?.tab, initialMorePath = link?.morePath, deepLinkEvent = runningDeepLink)
       }
     }
   }
+
+  override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    deepLinkFrom(intent)?.let { runningDeepLink = DeepLinkEvent(++deepLinkSeq, it) }
+  }
+
+  private fun deepLinkFrom(intent: Intent?): DeepLink? =
+    deepLinkFrom(intent?.getStringExtra(EXTRA_OPEN_TAB), intent?.getStringExtra(EXTRA_MORE_PATH))
 }
+
+/** A deep link that arrived at a running activity; [seq] makes every arrival distinct. */
+data class DeepLinkEvent(val seq: Long, val link: DeepLink)
 
 /**
  * The themed surface every screen is drawn on, sized to keep [content] above the
@@ -209,10 +221,16 @@ private const val VERSION_JSON_URL = "https://github.com/fiddur/aurboda/releases
 
 @Suppress("ASSIGNED_VALUE_IS_NEVER_READ") // Compose state vars trigger false "assigned but never read" warnings
 @Composable
-fun AurbodaApp(initialTab: MainTab? = null, initialMorePath: String? = null) {
+fun AurbodaApp(
+  initialTab: MainTab? = null,
+  initialMorePath: String? = null,
+  deepLinkEvent: DeepLinkEvent? = null,
+) {
   // A widget/notification deep link into a More web page opens it on first
   // composition; tapping More later returns to the hub (AppState.selectTab).
   val appState = rememberAppState(initialTab = initialTab, initialMorePath = initialMorePath)
+  // ...and one that arrives while the app is running (onNewIntent) navigates in place.
+  LaunchedEffect(deepLinkEvent) { deepLinkEvent?.let { appState.open(it.link) } }
   val context = LocalContext.current
   val scope = rememberCoroutineScope()
   val ktorHttpClient = remember { syncHttpClient() }
@@ -796,6 +814,8 @@ fun HealthConnectScreen(
                 reporter.end()
               }
               net.aurboda.widget.HrZoneWidgetProvider
+                .triggerUpdate(context)
+              net.aurboda.widget.ChallengeWidgetProvider
                 .triggerUpdate(context)
             }
           }

--- a/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
+++ b/apps/android/app/src/main/java/net/aurboda/SyncWorker.kt
@@ -13,6 +13,7 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import net.aurboda.widget.ChallengeWidgetProvider
 import net.aurboda.widget.HrZoneWidgetProvider
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -142,6 +143,7 @@ class SyncWorker(
       }
 
       HrZoneWidgetProvider.triggerUpdate(applicationContext)
+      ChallengeWidgetProvider.triggerUpdate(applicationContext)
       reporter.end()
       finishAttempt(attemptAt, BackgroundSyncResult.Success)
     } catch (e: Exception) {

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/ChallengeWidgetConfigScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/ChallengeWidgetConfigScreen.kt
@@ -1,0 +1,145 @@
+package net.aurboda.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import net.aurboda.widget.ChallengePick
+import net.aurboda.widget.challengeDateRange
+
+/** What the challenge-widget configuration screen is showing. */
+sealed interface ChallengeWidgetConfigState {
+    data object Loading : ChallengeWidgetConfigState
+
+    /** No credentials on the device: the widget can't list (or later show) anything. */
+    data object SignedOut : ChallengeWidgetConfigState
+
+    data class Error(val message: String) : ChallengeWidgetConfigState
+
+    data class Ready(val picks: List<ChallengePick>) : ChallengeWidgetConfigState
+}
+
+/**
+ * The widget configuration UI: pick which challenge — hosted or joined — a newly
+ * placed (or reconfigured) widget should follow. Pure presentation; the activity
+ * loads the picks and persists the choice.
+ */
+@Composable
+fun ChallengeWidgetConfigScreen(
+    state: ChallengeWidgetConfigState,
+    onPick: (ChallengePick) -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize().windowInsetsPadding(WindowInsets.safeDrawing)) {
+        Text(
+            "Choose a challenge",
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
+        )
+        Text(
+            "The widget shows its race chart and leaderboard, and opens it when tapped.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 20.dp),
+        )
+        when (state) {
+            ChallengeWidgetConfigState.Loading -> Centered { CircularProgressIndicator() }
+            ChallengeWidgetConfigState.SignedOut ->
+                Centered {
+                    Text(
+                        "Sign in to Aurboda first, then add the widget.",
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            is ChallengeWidgetConfigState.Error ->
+                Centered {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text(state.message, textAlign = TextAlign.Center)
+                        Button(onClick = onRetry) { Text("Retry") }
+                    }
+                }
+            is ChallengeWidgetConfigState.Ready ->
+                if (state.picks.isEmpty()) {
+                    Centered {
+                        Text(
+                            "You don't host or take part in any challenge yet. Create or join one on the Challenges page, then add the widget.",
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                } else {
+                    PickList(state.picks, onPick)
+                }
+        }
+    }
+}
+
+@Composable
+private fun Centered(content: @Composable () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) { content() }
+}
+
+@Composable
+private fun PickList(picks: List<ChallengePick>, onPick: (ChallengePick) -> Unit) {
+    val hosted = picks.filter { it.hosted }
+    val joined = picks.filter { !it.hosted }
+    LazyColumn(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
+        if (hosted.isNotEmpty()) {
+            item { SectionHeader("Hosted by you") }
+            items(hosted, key = { "h:" + it.url }) { PickRow(it, onPick) }
+        }
+        if (joined.isNotEmpty()) {
+            item { SectionHeader("Joined") }
+            items(joined, key = { "j:" + it.url }) { PickRow(it, onPick) }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        title,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(start = 20.dp, top = 16.dp, end = 20.dp, bottom = 4.dp),
+    )
+}
+
+@Composable
+private fun PickRow(pick: ChallengePick, onPick: (ChallengePick) -> Unit) {
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth().clickable { onPick(pick) }.padding(horizontal = 20.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text(pick.name, style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "${pick.detail} · ${challengeDateRange(pick.startTs, pick.endTs, pick.timezone)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp))
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/MoreScreen.kt
@@ -23,7 +23,11 @@ import net.aurboda.CredentialsManager
 
 /** A destination reachable from the "More" hub. */
 sealed interface MoreDestination {
-    /** A web page rendered in an embedded WebView at [path] (e.g. "/timeline"). */
+    /**
+     * A web page rendered in an embedded WebView: a site path on the user's own
+     * server (e.g. "/timeline"), or an absolute URL for a page hosted on another
+     * Aurboda instance (a challenge widget deep link to a joined remote challenge).
+     */
     data class Web(val path: String) : MoreDestination
 
     /** The native live-sensor (BLE) screen. */
@@ -34,6 +38,18 @@ sealed interface MoreDestination {
 }
 
 data class MoreItem(val label: String, val destination: MoreDestination)
+
+/**
+ * The URL an embedded page loads for a [MoreDestination.Web]: site paths are
+ * resolved against [serverUrl], absolute URLs are taken as-is; both get the
+ * `embed=1` flag that hides the web app's chrome.
+ */
+fun embeddedPageUrl(serverUrl: String, path: String): String {
+    val absolute = path.startsWith("http://") || path.startsWith("https://")
+    val page = if (absolute) path else "${serverUrl.trimEnd('/')}$path"
+    val separator = if (page.contains('?')) '&' else '?'
+    return "$page${separator}embed=1"
+}
 
 data class MoreGroup(val header: String, val items: List<MoreItem>)
 
@@ -114,7 +130,7 @@ fun MoreScreen(
             when (dest) {
                 is MoreDestination.Web ->
                     EmbeddedWebScreen(
-                        url = "${credentials.serverUrl.trimEnd('/')}${dest.path}?embed=1",
+                        url = embeddedPageUrl(credentials.serverUrl, dest.path),
                         baseUrl = credentials.serverUrl,
                         username = credentials.username,
                         authToken = credentials.authToken,

--- a/apps/android/app/src/main/java/net/aurboda/widget/ChallengeChart.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/ChallengeChart.kt
@@ -1,0 +1,78 @@
+package net.aurboda.widget
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+
+/** Longest bitmap edge we hand to RemoteViews — keeps the parcel well under the binder limit. */
+private const val MAX_CHART_PX = 800
+
+/**
+ * Draw the race chart — one cumulative line per member with a translucent area
+ * under it, over the whole challenge window so how far the race has run is
+ * visible — into a bitmap RemoteViews can show. The x-axis spans
+ * [startMillis, endMillis) and y from zero to just above the leading total.
+ * Nothing is drawn but a baseline when there are no series.
+ */
+fun drawRaceChart(
+    widthPx: Int,
+    heightPx: Int,
+    density: Float,
+    series: List<RaceSeries>,
+    startMillis: Long,
+    endMillis: Long,
+): Bitmap {
+    val w = widthPx.coerceIn(1, MAX_CHART_PX)
+    val h = heightPx.coerceIn(1, MAX_CHART_PX)
+    val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    val stroke = 2f * density
+    val inset = stroke // keep round line caps inside the bitmap
+    val plotW = (w - 2 * inset).coerceAtLeast(1f)
+    val plotH = (h - 2 * inset).coerceAtLeast(1f)
+
+    val span = (endMillis - startMillis).coerceAtLeast(1L).toDouble()
+    val maxValue = series.maxOfOrNull { s -> s.points.maxOfOrNull { it.value } ?: 0.0 } ?: 0.0
+    val yMax = if (maxValue > 0) maxValue * 1.05 else 1.0
+
+    fun x(t: Long): Float = (inset + plotW * ((t - startMillis) / span)).toFloat().coerceIn(inset, inset + plotW)
+    fun y(v: Double): Float = (inset + plotH - plotH * (v / yMax)).toFloat()
+
+    val baseline = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(0x40, 0xFF, 0xFF, 0xFF)
+        strokeWidth = 1f * density
+    }
+    canvas.drawLine(inset, inset + plotH, inset + plotW, inset + plotH, baseline)
+
+    val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    val line = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = stroke
+        strokeCap = Paint.Cap.ROUND
+        strokeJoin = Paint.Join.ROUND
+    }
+
+    // Areas first so no fill covers another member's line.
+    for (s in series) {
+        if (s.points.size < 2) continue
+        val area = Path()
+        area.moveTo(x(s.points.first().timeMillis), inset + plotH)
+        for (p in s.points) area.lineTo(x(p.timeMillis), y(p.value))
+        area.lineTo(x(s.points.last().timeMillis), inset + plotH)
+        area.close()
+        fill.color = (s.color and 0x00FFFFFF) or (0x22 shl 24)
+        canvas.drawPath(area, fill)
+    }
+    for (s in series) {
+        if (s.points.size < 2) continue
+        val path = Path()
+        path.moveTo(x(s.points.first().timeMillis), y(s.points.first().value))
+        for (p in s.points.drop(1)) path.lineTo(x(p.timeMillis), y(p.value))
+        line.color = s.color
+        canvas.drawPath(path, line)
+    }
+    return bitmap
+}

--- a/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetConfigActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetConfigActivity.kt
@@ -1,0 +1,85 @@
+package net.aurboda.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
+import net.aurboda.CredentialsManager
+import net.aurboda.DataResult
+import net.aurboda.fetchChallengeParticipations
+import net.aurboda.fetchChallenges
+import net.aurboda.syncHttpClient
+import net.aurboda.ui.screens.ChallengeWidgetConfigScreen
+import net.aurboda.ui.screens.ChallengeWidgetConfigState
+import net.aurboda.ui.theme.AurbodaAppTheme
+
+/**
+ * Launched by the launcher when a challenge widget is placed (and from the
+ * widget's reconfigure affordance): lists the user's hosted and joined
+ * challenges, stores the pick for this widget id and kicks off its first render.
+ * Cancelling (back) leaves the result as RESULT_CANCELED so the launcher
+ * discards the half-added widget.
+ */
+class ChallengeWidgetConfigActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setResult(RESULT_CANCELED)
+        val appWidgetId =
+            intent?.extras?.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID)
+                ?: AppWidgetManager.INVALID_APPWIDGET_ID
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+
+        setContent {
+            AurbodaAppTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    var state by remember { mutableStateOf<ChallengeWidgetConfigState>(ChallengeWidgetConfigState.Loading) }
+                    val scope = rememberCoroutineScope()
+                    LaunchedEffect(Unit) { state = loadChallengePicks(applicationContext) }
+                    ChallengeWidgetConfigScreen(
+                        state = state,
+                        onPick = { pick ->
+                            saveChallengeWidgetConfig(this, appWidgetId, ChallengeWidgetConfig(url = pick.url, name = pick.name))
+                            ChallengeWidgetWorker.enqueue(this)
+                            setResult(RESULT_OK, Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId))
+                            finish()
+                        },
+                        onRetry = {
+                            state = ChallengeWidgetConfigState.Loading
+                            scope.launch { state = loadChallengePicks(applicationContext) }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** The pickable challenges for the signed-in user, or why there are none. */
+suspend fun loadChallengePicks(context: Context): ChallengeWidgetConfigState {
+    val credentials = CredentialsManager.getCredentials(context) ?: return ChallengeWidgetConfigState.SignedOut
+    val httpClient = syncHttpClient()
+    try {
+        val hosted = fetchChallenges(httpClient, credentials.apiUrl, credentials.authToken)
+        val joined = fetchChallengeParticipations(httpClient, credentials.apiUrl, credentials.authToken)
+        if (hosted !is DataResult.Success || joined !is DataResult.Success) {
+            return ChallengeWidgetConfigState.Error("Couldn't load your challenges. Check your connection and try again.")
+        }
+        return ChallengeWidgetConfigState.Ready(challengePicks(hosted.data, joined.data))
+    } finally {
+        httpClient.close()
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetData.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetData.kt
@@ -1,0 +1,55 @@
+package net.aurboda.widget
+
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import net.aurboda.CredentialsManager
+import net.aurboda.DataResult
+import net.aurboda.api.models.ChallengeStanding
+import net.aurboda.fetchChallengeParticipations
+import net.aurboda.fetchChallenges
+import net.aurboda.fetchPublicChallengeStandings
+import net.aurboda.parseChallengeUrl
+import net.aurboda.resolveApiBase
+
+/** Everything one widget render needs: the challenge itself and its current standings. */
+data class ChallengeWidgetData(val summary: ChallengeSummary, val standings: List<ChallengeStanding>)
+
+/**
+ * Load a widget's challenge: the name/unit/window come from the user's own
+ * instance (hosted list + participations, so a rename or a left challenge is
+ * reflected), the standings from whichever instance hosts the challenge (via its
+ * public standings endpoint, discovered like a federated join). The three
+ * requests run concurrently.
+ */
+suspend fun loadChallengeWidgetData(
+    httpClient: HttpClient,
+    credentials: CredentialsManager.Credentials,
+    challengeUrl: String,
+): DataResult<ChallengeWidgetData> {
+    val parsed = parseChallengeUrl(challengeUrl) ?: return DataResult.Error("Not a challenge link")
+    return coroutineScope {
+        val hosted = async { fetchChallenges(httpClient, credentials.apiUrl, credentials.authToken) }
+        val joined = async { fetchChallengeParticipations(httpClient, credentials.apiUrl, credentials.authToken) }
+        val standings =
+            async {
+                when (val apiBase = resolveApiBase(httpClient, credentials, parsed.base)) {
+                    is DataResult.Success ->
+                        fetchPublicChallengeStandings(httpClient, apiBase.data, parsed.username, parsed.slug)
+                    is DataResult.Error -> apiBase
+                }
+            }
+
+        val hostedResult = hosted.await()
+        val joinedResult = joined.await()
+        val standingsResult = standings.await()
+        if (hostedResult !is DataResult.Success || joinedResult !is DataResult.Success) {
+            return@coroutineScope DataResult.Error("Couldn't load challenges")
+        }
+        if (standingsResult !is DataResult.Success) return@coroutineScope DataResult.Error("Couldn't load standings")
+        val summary =
+            findChallengeSummary(challengeUrl, hostedResult.data, joinedResult.data)
+                ?: return@coroutineScope DataResult.Error("Challenge no longer available")
+        DataResult.Success(ChallengeWidgetData(summary, standingsResult.data))
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetModel.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetModel.kt
@@ -1,0 +1,295 @@
+package net.aurboda.widget
+
+import net.aurboda.api.models.Challenge
+import net.aurboda.api.models.ChallengeParticipation
+import net.aurboda.api.models.ChallengeStanding
+import java.text.NumberFormat
+import java.time.DateTimeException
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.roundToLong
+
+/**
+ * Pure logic behind the challenge home-screen widget: which challenges can be
+ * picked, how standings become race-chart series and leaderboard rows, and how
+ * the widget lays itself out at a given size. No Android framework types, so
+ * everything here is unit-testable.
+ */
+
+/**
+ * Member line colours, in leaderboard order — the same palette (and order) as the
+ * web race chart / leaderboard (`apps/web/src/pages/Challenges/PublicChallenge.tsx`),
+ * so a member has the same colour on the phone as on the web page.
+ */
+val CHALLENGE_MEMBER_COLORS: IntArray =
+    intArrayOf(
+        0xFF8B5CF6.toInt(),
+        0xFF10B981.toInt(),
+        0xFF3B82F6.toInt(),
+        0xFFF59E0B.toInt(),
+        0xFFEF4444.toInt(),
+        0xFFEC4899.toInt(),
+        0xFF14B8A6.toInt(),
+        0xFFA855F7.toInt(),
+    )
+
+fun challengeMemberColor(index: Int): Int = CHALLENGE_MEMBER_COLORS[index % CHALLENGE_MEMBER_COLORS.size]
+
+const val DAY_MILLIS: Long = 24L * 60 * 60 * 1000
+
+/** A challenge the widget can be pointed at: hosted by the user, or one they joined. */
+data class ChallengePick(
+    val url: String,
+    val name: String,
+    /** e.g. "steps · sum" */
+    val detail: String,
+    val hosted: Boolean,
+    val startTs: String,
+    val endTs: String,
+    /** IANA zone the window was chosen in — dates are rendered in it, as on the web. */
+    val timezone: String,
+)
+
+/**
+ * The challenges offered in the widget configuration screen: everything the user
+ * hosts, then everything they are still an active member of. Withdrawn
+ * participations are left out — there is nothing to race in.
+ */
+fun challengePicks(hosted: List<Challenge>, joined: List<ChallengeParticipation>): List<ChallengePick> {
+    val own =
+        hosted.map {
+            ChallengePick(
+                url = it.shareUrl,
+                name = it.name,
+                detail = "${it.spec.unit} · ${it.spec.aggregation.value}",
+                hosted = true,
+                startTs = it.startTs,
+                endTs = it.endTs,
+                timezone = it.timezone,
+            )
+        }
+    val others =
+        joined
+            .filter { it.status == ChallengeParticipation.Status.active }
+            .map {
+                ChallengePick(
+                    url = it.challengeUrl,
+                    name = it.name,
+                    detail = "${it.spec.unit} · ${it.spec.aggregation.value}",
+                    hosted = false,
+                    startTs = it.startTs,
+                    endTs = it.endTs,
+                    timezone = it.timezone,
+                )
+            }
+    return own + others
+}
+
+/** What the widget shows about the challenge itself (name, unit, window). */
+data class ChallengeSummary(
+    val url: String,
+    val name: String,
+    val unit: String,
+    val startMillis: Long,
+    val endMillis: Long,
+)
+
+/** Find [url] among the user's hosted / joined challenges (trailing slashes ignored). */
+fun findChallengeSummary(
+    url: String,
+    hosted: List<Challenge>,
+    joined: List<ChallengeParticipation>,
+): ChallengeSummary? {
+    val wanted = url.trimEnd('/')
+    hosted.firstOrNull { it.shareUrl.trimEnd('/') == wanted }?.let {
+        return ChallengeSummary(it.shareUrl, it.name, it.spec.unit, parseInstantMillis(it.startTs), parseInstantMillis(it.endTs))
+    }
+    joined.firstOrNull { it.challengeUrl.trimEnd('/') == wanted }?.let {
+        return ChallengeSummary(it.challengeUrl, it.name, it.spec.unit, parseInstantMillis(it.startTs), parseInstantMillis(it.endTs))
+    }
+    return null
+}
+
+/** Epoch millis of an ISO-8601 instant; 0 if it doesn't parse (a bad value must not crash a widget). */
+fun parseInstantMillis(iso: String): Long =
+    try {
+        Instant.parse(iso).toEpochMilli()
+    } catch (e: DateTimeParseException) {
+        0L
+    }
+
+/** One point of a member's cumulative line. */
+data class RacePoint(val timeMillis: Long, val value: Double)
+
+/** One member's line in the race chart. */
+data class RaceSeries(val color: Int, val points: List<RacePoint>)
+
+/**
+ * The bucket length the standings were aggregated with, inferred as the smallest
+ * gap between consecutive bucket starts of any member (the host doesn't send it
+ * on this endpoint). Falls back to a day when nobody has two buckets yet.
+ */
+fun inferBucketMillis(standings: List<ChallengeStanding>): Long {
+    var best = Long.MAX_VALUE
+    for (s in standings) {
+        val starts = s.buckets.map { parseInstantMillis(it.bucketStart) }.sorted()
+        for (i in 1 until starts.size) {
+            val gap = starts[i] - starts[i - 1]
+            if (gap > 0 && gap < best) best = gap
+        }
+    }
+    return if (best == Long.MAX_VALUE) DAY_MILLIS else best
+}
+
+/**
+ * A member's running total as a line: a zero point on the start line, then the
+ * cumulative total plotted at the *end* of each bucket (a bucket's steps are only
+ * fully "in" when it is over) — the same shape as the web race chart.
+ */
+fun cumulativeSeries(
+    standing: ChallengeStanding,
+    color: Int,
+    startMillis: Long,
+    bucketMillis: Long,
+): RaceSeries {
+    val points = ArrayList<RacePoint>(standing.buckets.size + 1)
+    points.add(RacePoint(startMillis, 0.0))
+    var running = 0.0
+    for (b in standing.buckets.sortedBy { it.bucketStart }) {
+        running += b.value
+        points.add(RacePoint(parseInstantMillis(b.bucketStart) + bucketMillis, running))
+    }
+    return RaceSeries(color, points)
+}
+
+/** One line of the widget leaderboard. */
+data class LeaderboardRow(
+    val rank: Int,
+    val name: String,
+    val color: Int,
+    val total: Double,
+    /** The signed-in user's own row (rendered emphasised). */
+    val isMe: Boolean,
+)
+
+/** Active members in leaderboard order, each with its palette colour and rank. */
+fun leaderboard(standings: List<ChallengeStanding>, myIdentityUrl: String?): List<LeaderboardRow> {
+    val me = myIdentityUrl?.trimEnd('/')
+    return standings
+        .filter { it.status == ChallengeStanding.Status.active }
+        .mapIndexed { i, s ->
+            LeaderboardRow(
+                rank = i + 1,
+                name = s.displayName,
+                color = challengeMemberColor(i),
+                total = s.total,
+                isMe = me != null && s.identityBaseUrl.trimEnd('/') == me,
+            )
+        }
+}
+
+/**
+ * The rows that fit in [maxRows]: the top of the table, except that the user's own
+ * row (if it would be cut) replaces the last visible one — a widget on your home
+ * screen should always show where *you* stand.
+ */
+fun visibleRows(rows: List<LeaderboardRow>, maxRows: Int): List<LeaderboardRow> {
+    if (maxRows <= 0) return emptyList()
+    if (rows.size <= maxRows) return rows
+    val top = rows.take(maxRows)
+    val me = rows.firstOrNull { it.isMe } ?: return top
+    if (top.any { it.isMe }) return top
+    return top.dropLast(1) + me
+}
+
+/**
+ * The signed-in user's federation identity (`<server>/u/<username>`) — what the
+ * host lists as `identity_base_url` for them in the standings.
+ */
+fun myIdentityUrl(serverUrl: String, username: String): String = "${serverUrl.trimEnd('/')}/u/$username"
+
+/** Widget-internal geometry, in dp. */
+object ChallengeWidgetGeometry {
+    const val PADDING = 8
+    const val HEADER = 30 // title + meta line
+    const val ROW = 15
+    const val MIN_CHART = 30
+    const val MIN_WIDTH_FOR_RANK = 130
+}
+
+/** How the widget divides its height between the race chart and leaderboard rows. */
+data class ChallengeWidgetLayout(
+    val rowCount: Int,
+    val chartHeightDp: Int,
+    val chartWidthDp: Int,
+    /** Rank numbers are dropped on the narrowest widgets so names keep some room. */
+    val showRank: Boolean,
+)
+
+/**
+ * Split a widget of [widthDp] × [heightDp] into chart + rows: as many leaderboard
+ * rows as fit above a minimum chart height (never more than [memberCount]), the
+ * rest of the height going to the chart. A 2×2 cell (~110 dp) yields two rows and
+ * a ~36 dp chart; taller widgets show more members, wider ones a longer chart.
+ */
+fun planChallengeWidgetLayout(widthDp: Float, heightDp: Float, memberCount: Int): ChallengeWidgetLayout {
+    val g = ChallengeWidgetGeometry
+    val available = (heightDp - 2 * g.PADDING - g.HEADER).coerceAtLeast(0f)
+    val roomForRows = floor((available - g.MIN_CHART) / g.ROW).toInt().coerceAtLeast(0)
+    val rows = minOf(memberCount, roomForRows).coerceAtLeast(if (memberCount > 0) 1 else 0)
+    val chart = (available - rows * g.ROW).toInt().coerceAtLeast(g.MIN_CHART)
+    val chartWidth = (widthDp - 2 * g.PADDING).toInt().coerceAtLeast(40)
+    return ChallengeWidgetLayout(
+        rowCount = rows,
+        chartHeightDp = chart,
+        chartWidthDp = chartWidth,
+        showRank = widthDp >= g.MIN_WIDTH_FOR_RANK,
+    )
+}
+
+/** "138,989" — a whole-number total with locale grouping, like the web leaderboard. */
+fun formatChallengeTotal(total: Double): String = NumberFormat.getIntegerInstance().format(total.roundToLong())
+
+/**
+ * The widget's second line: the unit and where the challenge is in its window
+ * ("steps · 13 days left", "steps · last day", "steps · starts in 2 days",
+ * "steps · ended"). [endMillis] is the exclusive window end.
+ */
+fun challengeMetaLine(unit: String, startMillis: Long, endMillis: Long, nowMillis: Long): String {
+    val phase =
+        when {
+            nowMillis < startMillis -> {
+                val days = ceil((startMillis - nowMillis).toDouble() / DAY_MILLIS).toInt()
+                if (days <= 1) "starts tomorrow" else "starts in $days days"
+            }
+            nowMillis >= endMillis -> "ended"
+            else -> {
+                val days = ceil((endMillis - nowMillis).toDouble() / DAY_MILLIS).toInt()
+                if (days <= 1) "last day" else "$days days left"
+            }
+        }
+    return "$unit · $phase"
+}
+
+/**
+ * "Aug 1 – Aug 31": the inclusive window of a challenge, rendered in the zone it
+ * was chosen in ([endTs] is the exclusive end, so step back one ms first). Falls
+ * back to the device zone for an unknown zone id.
+ */
+fun challengeDateRange(startTs: String, endTs: String, timezone: String, locale: Locale = Locale.getDefault()): String {
+    val zone =
+        try {
+            ZoneId.of(timezone)
+        } catch (e: DateTimeException) {
+            ZoneId.systemDefault()
+        }
+    val fmt = DateTimeFormatter.ofPattern("MMM d", locale).withZone(zone)
+    val start = Instant.ofEpochMilli(parseInstantMillis(startTs))
+    val end = Instant.ofEpochMilli(parseInstantMillis(endTs) - 1)
+    return "${fmt.format(start)} – ${fmt.format(end)}"
+}

--- a/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetPrefs.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetPrefs.kt
@@ -1,0 +1,29 @@
+package net.aurboda.widget
+
+import android.content.Context
+
+private const val PREFS_NAME = "challenge_widget"
+
+/** Which challenge one widget instance shows. [name] is a cached label for the loading/error states. */
+data class ChallengeWidgetConfig(val url: String, val name: String)
+
+fun saveChallengeWidgetConfig(context: Context, appWidgetId: Int, config: ChallengeWidgetConfig) {
+    context
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        .edit()
+        .putString("url_$appWidgetId", config.url)
+        .putString("name_$appWidgetId", config.name)
+        .apply()
+}
+
+fun loadChallengeWidgetConfig(context: Context, appWidgetId: Int): ChallengeWidgetConfig? {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val url = prefs.getString("url_$appWidgetId", null) ?: return null
+    return ChallengeWidgetConfig(url = url, name = prefs.getString("name_$appWidgetId", null) ?: "")
+}
+
+fun clearChallengeWidgetConfig(context: Context, appWidgetIds: IntArray) {
+    val editor = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
+    for (id in appWidgetIds) editor.remove("url_$id").remove("name_$id")
+    editor.apply()
+}

--- a/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/ChallengeWidgetProvider.kt
@@ -1,0 +1,313 @@
+package net.aurboda.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.util.SizeF
+import android.widget.RemoteViews
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import android.graphics.Typeface
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.StyleSpan
+import android.view.View
+import io.ktor.client.HttpClient
+import net.aurboda.CredentialsManager
+import net.aurboda.DataResult
+import net.aurboda.MainActivity
+import net.aurboda.R
+import net.aurboda.api.models.ChallengeStanding
+import net.aurboda.parseChallengeUrl
+import net.aurboda.syncHttpClient
+
+private const val TAG = "ChallengeWidget"
+
+/**
+ * Home-screen widget showing one challenge: its race chart and leaderboard, tap
+ * to open that challenge in the app. Which challenge is chosen per widget in
+ * [ChallengeWidgetConfigActivity]. All rendering — including the network fetch —
+ * happens in [ChallengeWidgetWorker]; the receiver itself only enqueues it, so
+ * a slow server can't hit the broadcast timeout.
+ */
+class ChallengeWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        Log.d(TAG, "onUpdate for ${appWidgetIds.size} widgets")
+        ChallengeWidgetWorker.enqueue(context)
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle,
+    ) {
+        // A resize changes how many leaderboard rows fit and the chart bitmap size.
+        ChallengeWidgetWorker.enqueue(context)
+    }
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        clearChallengeWidgetConfig(context, appWidgetIds)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action == ACTION_UPDATE_WIDGETS) ChallengeWidgetWorker.enqueue(context)
+    }
+
+    companion object {
+        const val ACTION_UPDATE_WIDGETS = "net.aurboda.ACTION_UPDATE_CHALLENGE_WIDGETS"
+
+        /** Refresh every challenge widget — called after a sync lands new data. */
+        fun triggerUpdate(context: Context) {
+            val intent = Intent(context, ChallengeWidgetProvider::class.java).apply { action = ACTION_UPDATE_WIDGETS }
+            context.sendBroadcast(intent)
+        }
+    }
+}
+
+/**
+ * Renders all challenge widgets: fetches each one's standings and pushes the
+ * RemoteViews. Enqueued (unique, appended) from the provider, the configuration
+ * screen and after background sync.
+ */
+class ChallengeWidgetWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result {
+        val manager = AppWidgetManager.getInstance(applicationContext)
+        val ids = manager.getAppWidgetIds(ComponentName(applicationContext, ChallengeWidgetProvider::class.java))
+        if (ids.isEmpty()) return Result.success()
+        val httpClient: HttpClient = syncHttpClient()
+        try {
+            for (id in ids) {
+                try {
+                    renderChallengeWidget(applicationContext, manager, id, httpClient)
+                } catch (e: Exception) {
+                    // One broken widget must not stop the others from refreshing.
+                    Log.e(TAG, "Rendering widget $id failed", e)
+                }
+            }
+        } finally {
+            httpClient.close()
+        }
+        return Result.success()
+    }
+
+    companion object {
+        private const val WORK_NAME = "challenge_widget_refresh"
+
+        fun enqueue(context: Context) {
+            val request = OneTimeWorkRequestBuilder<ChallengeWidgetWorker>().build()
+            // APPEND_OR_REPLACE: a refresh requested while one is running (e.g. a widget
+            // was just configured) runs after it instead of being dropped or cutting it short.
+            WorkManager.getInstance(context).enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.APPEND_OR_REPLACE, request)
+        }
+    }
+}
+
+/** Fetch one widget's data and push its views (or an explanatory state) to the launcher. */
+suspend fun renderChallengeWidget(
+    context: Context,
+    appWidgetManager: AppWidgetManager,
+    appWidgetId: Int,
+    httpClient: HttpClient,
+) {
+    val config = loadChallengeWidgetConfig(context, appWidgetId)
+    if (config == null) {
+        appWidgetManager.updateAppWidget(appWidgetId, unconfiguredViews(context, appWidgetId))
+        return
+    }
+    val credentials = CredentialsManager.getCredentials(context)
+    if (credentials == null) {
+        appWidgetManager.updateAppWidget(
+            appWidgetId,
+            statusViews(context, appWidgetId, config, serverUrl = null, "Sign in to Aurboda to see standings"),
+        )
+        return
+    }
+    val views =
+        when (val data = loadChallengeWidgetData(httpClient, credentials, config.url)) {
+            is DataResult.Error -> {
+                Log.w(TAG, "Widget $appWidgetId: ${data.message}")
+                statusViews(context, appWidgetId, config, credentials.serverUrl, data.message)
+            }
+            is DataResult.Success -> {
+                // Refresh the cached name so a rename shows up in the loading/error states too.
+                if (data.data.summary.name != config.name) {
+                    saveChallengeWidgetConfig(context, appWidgetId, config.copy(name = data.data.summary.name))
+                }
+                challengeViews(context, appWidgetManager, appWidgetId, credentials, data.data)
+            }
+        }
+    appWidgetManager.updateAppWidget(appWidgetId, views)
+}
+
+/** The sizes the launcher may show this widget at (portrait/landscape), in dp. */
+fun widgetSizes(appWidgetManager: AppWidgetManager, appWidgetId: Int): List<SizeF> {
+    val options = appWidgetManager.getAppWidgetOptions(appWidgetId)
+    val sizes = options.getParcelableArrayList(AppWidgetManager.OPTION_APPWIDGET_SIZES, SizeF::class.java)
+    if (!sizes.isNullOrEmpty()) return sizes.take(16)
+    val minW = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 0)
+    val minH = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 0)
+    return listOf(SizeF(if (minW > 0) minW.toFloat() else 110f, if (minH > 0) minH.toFloat() else 110f))
+}
+
+private fun openChallengeIntent(
+    context: Context,
+    appWidgetId: Int,
+    config: ChallengeWidgetConfig,
+    serverUrl: String?,
+): PendingIntent {
+    val path = challengeDeepLinkPath(serverUrl, config.url)
+    val intent =
+        Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(MainActivity.EXTRA_OPEN_TAB, MainActivity.TAB_MORE)
+            putExtra(MainActivity.EXTRA_MORE_PATH, path)
+        }
+    return PendingIntent.getActivity(
+        context,
+        appWidgetId,
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
+}
+
+private fun configureIntent(context: Context, appWidgetId: Int): PendingIntent {
+    val intent =
+        Intent(context, ChallengeWidgetConfigActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        }
+    return PendingIntent.getActivity(
+        context,
+        appWidgetId,
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
+}
+
+/**
+ * The More-tab path the widget deep-links to: a site-relative `/u/<owner>/<slug>`
+ * for a challenge on the user's own instance, or the absolute URL when the
+ * challenge is hosted elsewhere (the embedded page then loads cross-instance).
+ */
+fun challengeDeepLinkPath(serverUrl: String?, challengeUrl: String): String {
+    val parsed = parseChallengeUrl(challengeUrl) ?: return challengeUrl
+    if (serverUrl != null && parsed.base.trimEnd('/') == serverUrl.trimEnd('/')) {
+        return "/u/${parsed.username}/${parsed.slug}"
+    }
+    return challengeUrl
+}
+
+private fun unconfiguredViews(context: Context, appWidgetId: Int): RemoteViews =
+    RemoteViews(context.packageName, R.layout.widget_challenge).apply {
+        setTextViewText(R.id.challenge_title, "Challenge")
+        setTextViewText(R.id.challenge_meta, "")
+        setViewVisibility(R.id.challenge_body, View.GONE)
+        setViewVisibility(R.id.challenge_status, View.VISIBLE)
+        setTextViewText(R.id.challenge_status, "Tap to choose a challenge")
+        setOnClickPendingIntent(R.id.widget_root, configureIntent(context, appWidgetId))
+    }
+
+private fun statusViews(
+    context: Context,
+    appWidgetId: Int,
+    config: ChallengeWidgetConfig,
+    serverUrl: String?,
+    message: String,
+): RemoteViews =
+    RemoteViews(context.packageName, R.layout.widget_challenge).apply {
+        setTextViewText(R.id.challenge_title, config.name.ifEmpty { "Challenge" })
+        setTextViewText(R.id.challenge_meta, "")
+        setViewVisibility(R.id.challenge_body, View.GONE)
+        setViewVisibility(R.id.challenge_status, View.VISIBLE)
+        setTextViewText(R.id.challenge_status, message)
+        setOnClickPendingIntent(R.id.widget_root, openChallengeIntent(context, appWidgetId, config, serverUrl))
+    }
+
+/** One RemoteViews per launcher size (the launcher picks the closest), all sharing the same click. */
+private fun challengeViews(
+    context: Context,
+    appWidgetManager: AppWidgetManager,
+    appWidgetId: Int,
+    credentials: CredentialsManager.Credentials,
+    data: ChallengeWidgetData,
+): RemoteViews {
+    val config = ChallengeWidgetConfig(url = data.summary.url, name = data.summary.name)
+    val click = openChallengeIntent(context, appWidgetId, config, credentials.serverUrl)
+    val nowMillis = System.currentTimeMillis()
+    val density = context.resources.displayMetrics.density
+    val rows = leaderboard(data.standings, myIdentityUrl(credentials.serverUrl, credentials.username))
+    val bucketMillis = inferBucketMillis(data.standings)
+    val series =
+        data.standings
+            .filter { it.status == ChallengeStanding.Status.active }
+            .mapIndexed { i, s -> cumulativeSeries(s, challengeMemberColor(i), data.summary.startMillis, bucketMillis) }
+
+    val perSize =
+        widgetSizes(appWidgetManager, appWidgetId).associateWith { size ->
+            val layout = planChallengeWidgetLayout(size.width, size.height, rows.size)
+            RemoteViews(context.packageName, R.layout.widget_challenge).apply {
+                setTextViewText(R.id.challenge_title, data.summary.name)
+                setTextViewText(
+                    R.id.challenge_meta,
+                    challengeMetaLine(data.summary.unit, data.summary.startMillis, data.summary.endMillis, nowMillis),
+                )
+                setViewVisibility(R.id.challenge_status, View.GONE)
+                setViewVisibility(R.id.challenge_body, View.VISIBLE)
+                setImageViewBitmap(
+                    R.id.race_chart,
+                    drawRaceChart(
+                        widthPx = (layout.chartWidthDp * density).toInt(),
+                        heightPx = (layout.chartHeightDp * density).toInt(),
+                        density = density,
+                        series = series,
+                        startMillis = data.summary.startMillis,
+                        endMillis = data.summary.endMillis,
+                    ),
+                )
+                removeAllViews(R.id.leaderboard)
+                val visible = visibleRows(rows, layout.rowCount)
+                setViewVisibility(
+                    R.id.leaderboard_empty,
+                    if (rows.isEmpty()) View.VISIBLE else View.GONE,
+                )
+                for (row in visible) addView(R.id.leaderboard, rowViews(context, row, layout.showRank))
+                setOnClickPendingIntent(R.id.widget_root, click)
+            }
+        }
+    return if (perSize.size == 1) perSize.values.first() else RemoteViews(perSize)
+}
+
+private fun rowViews(context: Context, row: LeaderboardRow, showRank: Boolean): RemoteViews =
+    RemoteViews(context.packageName, R.layout.widget_challenge_row).apply {
+        setTextViewText(R.id.member_rank, row.rank.toString())
+        setViewVisibility(R.id.member_rank, if (showRank) View.VISIBLE else View.GONE)
+        setInt(R.id.member_color, "setColorFilter", row.color)
+        val name: CharSequence =
+            if (row.isMe) {
+                SpannableString(row.name).apply {
+                    setSpan(
+                        StyleSpan(Typeface.BOLD),
+                        0,
+                        length,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                    )
+                }
+            } else {
+                row.name
+            }
+        setTextViewText(R.id.member_name, name)
+        setTextViewText(R.id.member_total, formatChallengeTotal(row.total))
+    }

--- a/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
+++ b/apps/android/app/src/main/java/net/aurboda/widget/HrZoneWidgetProvider.kt
@@ -51,8 +51,8 @@ class HrZoneWidgetProvider : AppWidgetProvider() {
     val views = RemoteViews(context.packageName, R.layout.widget_hr_zones)
 
     // Tapping the widget opens the app on the Goals page. SINGLE_TOP reuses an
-    // already-running app (keeping whatever screen it's on) rather than
-    // recreating it; the Goals deep link only applies on a cold start.
+    // already-running app rather than recreating it; MainActivity then follows
+    // the deep link from onNewIntent (or from onCreate on a cold start).
     val openAppIntent =
       Intent(context, MainActivity::class.java).apply {
         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP

--- a/apps/android/app/src/main/res/drawable/widget_challenge_preview_chart.xml
+++ b/apps/android/app/src/main/res/drawable/widget_challenge_preview_chart.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Sample race chart for the widget picker preview (two cumulative lines with area fills). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="120dp"
+    android:height="40dp"
+    android:viewportWidth="120"
+    android:viewportHeight="40">
+    <path
+        android:fillColor="#308B5CF6"
+        android:pathData="M2,38 L20,32 L38,27 L56,17 L74,12 L88,6 L88,38 Z" />
+    <path
+        android:fillColor="#3010B981"
+        android:pathData="M2,38 L20,29 L38,25 L56,21 L74,15 L88,11 L88,38 Z" />
+    <path
+        android:pathData="M2,38 L118,38"
+        android:strokeColor="#40FFFFFF"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M2,38 L20,32 L38,27 L56,17 L74,12 L88,6"
+        android:strokeColor="#8B5CF6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+    <path
+        android:pathData="M2,38 L20,29 L38,25 L56,21 L74,15 L88,11"
+        android:strokeColor="#10B981"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/apps/android/app/src/main/res/drawable/widget_color_dot.xml
+++ b/apps/android/app/src/main/res/drawable/widget_color_dot.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- A white disc; the widget tints it per member with setColorFilter. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FFFFFFFF" />
+    <size
+        android:width="8dp"
+        android:height="8dp" />
+</shape>

--- a/apps/android/app/src/main/res/layout/widget_challenge.xml
+++ b/apps/android/app/src/main/res/layout/widget_challenge.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Challenge widget: title + meta line, a race-chart bitmap that takes whatever
+    height is left, and a leaderboard whose rows the provider adds dynamically
+    (RemoteViews.addView) sized to the widget. `challenge_status` replaces the body
+    for the unconfigured / signed-out / loading / error states.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/challenge_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="Challenge"
+            android:textColor="#FFFFFFFF"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/challenge_meta"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="#99FFFFFF"
+            android:textSize="10sp" />
+
+        <LinearLayout
+            android:id="@+id/challenge_body"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/race_chart"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:layout_marginTop="2dp"
+                android:layout_marginBottom="2dp"
+                android:importantForAccessibility="no"
+                android:scaleType="fitXY" />
+
+            <LinearLayout
+                android:id="@+id/leaderboard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <TextView
+                android:id="@+id/leaderboard_empty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="No members yet"
+                android:textColor="#88FFFFFF"
+                android:textSize="11sp"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/challenge_status"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="Loading…"
+            android:textColor="#88FFFFFF"
+            android:textSize="12sp" />
+    </LinearLayout>
+</FrameLayout>

--- a/apps/android/app/src/main/res/layout/widget_challenge_preview.xml
+++ b/apps/android/app/src/main/res/layout/widget_challenge_preview.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Static sample of the challenge widget for the launcher's widget picker. -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:text="August steppers"
+            android:textColor="#FFFFFFFF"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:text="steps · 13 days left"
+            android:textColor="#99FFFFFF"
+            android:textSize="10sp" />
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:layout_marginTop="2dp"
+            android:layout_marginBottom="2dp"
+            android:importantForAccessibility="no"
+            android:scaleType="fitXY"
+            android:src="@drawable/widget_challenge_preview_chart" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="15dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="14dp"
+                android:layout_height="wrap_content"
+                android:text="1"
+                android:textColor="#88FFFFFF"
+                android:textSize="10sp" />
+            <ImageView
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:layout_marginEnd="6dp"
+                android:importantForAccessibility="no"
+                android:src="@drawable/widget_color_dot"
+                android:tint="#8B5CF6" />
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:maxLines="1"
+                android:text="delvoriah"
+                android:textColor="#FFFFFFFF"
+                android:textSize="11sp" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="138,989"
+                android:textColor="#FFFFFFFF"
+                android:textSize="11sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="15dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="14dp"
+                android:layout_height="wrap_content"
+                android:text="2"
+                android:textColor="#88FFFFFF"
+                android:textSize="10sp" />
+            <ImageView
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:layout_marginEnd="6dp"
+                android:importantForAccessibility="no"
+                android:src="@drawable/widget_color_dot"
+                android:tint="#10B981" />
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:maxLines="1"
+                android:text="fiddur"
+                android:textColor="#FFFFFFFF"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="120,055"
+                android:textColor="#FFFFFFFF"
+                android:textSize="11sp" />
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/apps/android/app/src/main/res/layout/widget_challenge_row.xml
+++ b/apps/android/app/src/main/res/layout/widget_challenge_row.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- One leaderboard line: rank, the member's chart colour, name, total. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="15dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/member_rank"
+        android:layout_width="14dp"
+        android:layout_height="wrap_content"
+        android:textColor="#88FFFFFF"
+        android:textSize="10sp" />
+
+    <ImageView
+        android:id="@+id/member_color"
+        android:layout_width="8dp"
+        android:layout_height="8dp"
+        android:layout_marginEnd="6dp"
+        android:importantForAccessibility="no"
+        android:src="@drawable/widget_color_dot" />
+
+    <TextView
+        android:id="@+id/member_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="#FFFFFFFF"
+        android:textSize="11sp" />
+
+    <TextView
+        android:id="@+id/member_total"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="6dp"
+        android:textColor="#FFFFFFFF"
+        android:textSize="11sp" />
+</LinearLayout>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="app_name">Aurboda</string>
     <string name="widget_description">Weekly HR zone minutes for Zone 2 and Zone 5</string>
     <string name="widget_name">HR Zones</string>
+    <string name="challenge_widget_name">Challenge</string>
+    <string name="challenge_widget_description">Race chart and leaderboard of a challenge you host or joined</string>
 </resources>

--- a/apps/android/app/src/main/res/xml/challenge_widget_info.xml
+++ b/apps/android/app/src/main/res/xml/challenge_widget_info.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="110dp"
+    android:maxResizeWidth="530dp"
+    android:maxResizeHeight="450dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/widget_challenge"
+    android:previewLayout="@layout/widget_challenge_preview"
+    android:configure="net.aurboda.widget.ChallengeWidgetConfigActivity"
+    android:widgetFeatures="reconfigurable"
+    android:widgetCategory="home_screen"
+    android:description="@string/challenge_widget_description" />

--- a/apps/android/app/src/test/java/net/aurboda/AppStateNavigationTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/AppStateNavigationTest.kt
@@ -95,4 +95,44 @@ class AppStateNavigationTest {
         state.selectTab(MainTab.More)
         assertNull(state.moreDestination)
     }
+
+    @Test
+    fun `a deep link arriving while running navigates to its More page`() {
+        val state = appState(initialTab = MainTab.Home)
+
+        state.open(DeepLink(MainTab.More, "/u/fiddur/august-steppers"))
+
+        assertEquals(MainTab.More, state.currentTab)
+        assertEquals(MoreDestination.Web("/u/fiddur/august-steppers"), state.moreDestination)
+    }
+
+    @Test
+    fun `a running deep link replaces the More sub-page already showing`() {
+        val state = appState(initialTab = MainTab.More, initialMoreDestination = MoreDestination.Web("/goals"))
+
+        state.open(DeepLink(MainTab.More, "https://other.example/u/anna/walk"))
+
+        assertEquals(MoreDestination.Web("https://other.example/u/anna/walk"), state.moreDestination)
+    }
+
+    @Test
+    fun `a running deep link to a plain tab just selects it`() {
+        val state = appState(initialTab = MainTab.More, initialMoreDestination = MoreDestination.Live)
+
+        state.open(DeepLink(MainTab.Feed))
+
+        assertEquals(MainTab.Feed, state.currentTab)
+        // The More sub-page is left as it was (tapping More clears it, as always).
+        assertEquals(MoreDestination.Live, state.moreDestination)
+    }
+
+    @Test
+    fun `deepLinkFrom decodes the launch extras`() {
+        assertEquals(DeepLink(MainTab.More, "/goals"), deepLinkFrom(MainActivity.TAB_MORE, "/goals"))
+        assertEquals(DeepLink(MainTab.Feed), deepLinkFrom(MainActivity.TAB_FEED, null))
+        // A More path only means something with the More tab.
+        assertEquals(DeepLink(MainTab.Add), deepLinkFrom(MainActivity.TAB_ADD, "/goals"))
+        assertNull(deepLinkFrom(null, "/goals"))
+        assertNull(deepLinkFrom("bogus", null))
+    }
 }

--- a/apps/android/app/src/test/java/net/aurboda/ChallengeApiTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/ChallengeApiTest.kt
@@ -1,0 +1,95 @@
+package net.aurboda
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+// Robolectric only for android.util.Log, which the error paths hit.
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class ChallengeApiTest {
+    private fun client(handler: (url: String, auth: String?) -> Pair<HttpStatusCode, String>): HttpClient =
+        HttpClient(
+            MockEngine { request ->
+                val (status, body) = handler(request.url.toString(), request.headers[HttpHeaders.Authorization])
+                respond(content = body, status = status, headers = headersOf(HttpHeaders.ContentType, "application/json"))
+            },
+        ) { install(ContentNegotiation) { json(appJson) } }
+
+    private val credentials = CredentialsManager.Credentials("https://aurboda.net", "fiddur", "tok")
+
+    @Test
+    fun `fetchPublicChallengeStandings hits the host's public endpoint, unauthenticated, and parses members`() = runTest {
+        var seen: Pair<String, String?>? = null
+        val http =
+            client { url, auth ->
+                seen = url to auth
+                HttpStatusCode.OK to
+                    """{"success":true,"members":[{"buckets":[{"bucket_start":"2026-08-01T00:00:00.000Z","value":4486}],
+                       "display_name":"fiddur","identity_base_url":"https://aurboda.net/u/fiddur","last_updated":null,
+                       "stale":false,"status":"active","total":4486}]}"""
+            }
+        val result = fetchPublicChallengeStandings(http, "https://aurboda.net/api/", "fiddur", "august steppers")
+        assertEquals("https://aurboda.net/api/public/fiddur/august%20steppers/standings", seen?.first)
+        assertEquals(null, seen?.second)
+        assertTrue(result is DataResult.Success)
+        val members = (result as DataResult.Success).data
+        assertEquals(1, members.size)
+        assertEquals(4486.0, members[0].total, 0.0)
+        assertEquals("2026-08-01T00:00:00.000Z", members[0].buckets[0].bucketStart)
+    }
+
+    @Test
+    fun `fetchChallenges sends the bearer token and unwraps the list`() = runTest {
+        var seenAuth: String? = null
+        val http =
+            client { _, auth ->
+                seenAuth = auth
+                HttpStatusCode.OK to
+                    """{"success":true,"challenges":[{"created_at":"2026-07-30T00:00:00.000Z","end_ts":"2026-08-31T22:00:00.000Z",
+                       "id":"11111111-1111-4111-8111-111111111111","name":"August steppers","share_url":"https://aurboda.net/u/fiddur/august-steppers",
+                       "slug":"august-steppers","spec":{"aggregation":"sum","bucket_size":"auto","pattern":"steps","source_type":"metric","unit":"steps"},
+                       "start_ts":"2026-07-31T22:00:00.000Z","timezone":"Europe/Stockholm","updated_at":"2026-07-30T00:00:00.000Z","visibility":"public"}]}"""
+            }
+        val result = fetchChallenges(http, "https://aurboda.net/api", "tok")
+        assertEquals("Bearer tok", seenAuth)
+        assertEquals("August steppers", (result as DataResult.Success).data.single().name)
+    }
+
+    @Test
+    fun `resolveApiBase answers the own instance locally and discovers others via well-known`() = runTest {
+        val urls = mutableListOf<String>()
+        val http =
+            client { url, _ ->
+                urls += url
+                HttpStatusCode.OK to
+                    """{"api_base":"https://other.example/api","federation":true,"product":"aurboda","version":"1.2.3"}"""
+            }
+        assertEquals(DataResult.Success("https://aurboda.net/api"), resolveApiBase(http, credentials, "https://aurboda.net/"))
+        assertTrue(urls.isEmpty())
+
+        assertEquals(DataResult.Success("https://other.example/api"), resolveApiBase(http, credentials, "https://other.example"))
+        assertEquals(listOf("https://other.example/.well-known/aurboda"), urls)
+    }
+
+    @Test
+    fun `discoverApiBase refuses an instance without federation and reports HTTP errors`() = runTest {
+        val noFed = client { _, _ -> HttpStatusCode.OK to """{"api_base":"x","federation":false,"product":"aurboda","version":"1"}""" }
+        assertTrue(discoverApiBase(noFed, "https://other.example") is DataResult.Error)
+
+        val missing = client { _, _ -> HttpStatusCode.NotFound to "" }
+        assertTrue(discoverApiBase(missing, "https://other.example") is DataResult.Error)
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/ui/EmbeddedPageUrlTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/ui/EmbeddedPageUrlTest.kt
@@ -1,0 +1,26 @@
+package net.aurboda.ui
+
+import net.aurboda.ui.screens.embeddedPageUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EmbeddedPageUrlTest {
+    @Test
+    fun `site paths resolve against the server URL with the embed flag`() {
+        assertEquals("https://aurboda.net/goals?embed=1", embeddedPageUrl("https://aurboda.net", "/goals"))
+        assertEquals("https://aurboda.net/goals?embed=1", embeddedPageUrl("https://aurboda.net/", "/goals"))
+    }
+
+    @Test
+    fun `absolute URLs load as-is with the embed flag`() {
+        assertEquals(
+            "https://other.example/u/anna/walk?embed=1",
+            embeddedPageUrl("https://aurboda.net", "https://other.example/u/anna/walk"),
+        )
+    }
+
+    @Test
+    fun `an existing query string is extended, not doubled`() {
+        assertEquals("https://aurboda.net/chart?metric=steps&embed=1", embeddedPageUrl("https://aurboda.net", "/chart?metric=steps"))
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/widget/ChallengeChartTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/widget/ChallengeChartTest.kt
@@ -1,0 +1,47 @@
+package net.aurboda.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class ChallengeChartTest {
+    private val start = parseInstantMillis("2026-07-31T22:00:00Z")
+    private val end = parseInstantMillis("2026-08-31T22:00:00Z")
+
+    @Test
+    fun `draws a bitmap of the requested size, capped to the RemoteViews-safe maximum`() {
+        val bmp = drawRaceChart(300, 120, 2f, emptyList(), start, end)
+        assertEquals(300, bmp.width)
+        assertEquals(120, bmp.height)
+
+        val huge = drawRaceChart(5000, 3000, 3f, emptyList(), start, end)
+        assertEquals(800, huge.width)
+        assertEquals(800, huge.height)
+    }
+
+    @Test
+    fun `paints a member's line in its colour`() {
+        val color = 0xFF10B981.toInt()
+        val series =
+            RaceSeries(
+                color,
+                listOf(RacePoint(start, 0.0), RacePoint(start + DAY_MILLIS * 10, 50_000.0), RacePoint(start + DAY_MILLIS * 17, 120_055.0)),
+            )
+        val bmp = drawRaceChart(310, 100, 1f, listOf(series), start, end)
+        // Somewhere along the line a pixel is (close to) the series colour; the far right, past
+        // the last point, is untouched apart from the baseline.
+        var found = false
+        for (x in 0 until bmp.width) for (y in 0 until bmp.height) {
+            if (bmp.getPixel(x, y) == color) found = true
+        }
+        assertEquals(true, found)
+        assertNotEquals(color, bmp.getPixel(bmp.width - 3, 10))
+    }
+}

--- a/apps/android/app/src/test/java/net/aurboda/widget/ChallengeWidgetModelTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/widget/ChallengeWidgetModelTest.kt
@@ -1,0 +1,257 @@
+package net.aurboda.widget
+
+import net.aurboda.api.models.Challenge
+import net.aurboda.api.models.ChallengeAggregation
+import net.aurboda.api.models.ChallengeBucketSize
+import net.aurboda.api.models.ChallengeParticipation
+import net.aurboda.api.models.ChallengeSourceType
+import net.aurboda.api.models.ChallengeSpec
+import net.aurboda.api.models.ChallengeStanding
+import net.aurboda.api.models.ChartDataBucket
+import net.aurboda.api.models.ShareVisibility
+import net.aurboda.parseChallengeUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+class ChallengeWidgetModelTest {
+    private val spec =
+        ChallengeSpec(
+            aggregation = ChallengeAggregation.sum,
+            bucketSize = ChallengeBucketSize.auto,
+            pattern = "steps",
+            sourceType = ChallengeSourceType.metric,
+            unit = "steps",
+        )
+
+    private fun hosted(name: String, url: String) =
+        Challenge(
+            createdAt = "2026-07-30T00:00:00.000Z",
+            endTs = "2026-08-31T22:00:00.000Z",
+            id = "c-$name",
+            name = name,
+            shareUrl = url,
+            slug = name,
+            spec = spec,
+            startTs = "2026-07-31T22:00:00.000Z",
+            timezone = "Europe/Stockholm",
+            updatedAt = "2026-07-30T00:00:00.000Z",
+            visibility = ShareVisibility.public,
+        )
+
+    private fun joined(name: String, url: String, status: ChallengeParticipation.Status = ChallengeParticipation.Status.active) =
+        ChallengeParticipation(
+            challengeUrl = url,
+            createdAt = "2026-07-30T00:00:00.000Z",
+            endTs = "2026-08-31T22:00:00.000Z",
+            hostIdentity = "https://other.example/u/host",
+            id = "p-$name",
+            name = name,
+            spec = spec,
+            startTs = "2026-07-31T22:00:00.000Z",
+            status = status,
+            timezone = "Europe/Stockholm",
+        )
+
+    private fun standing(
+        name: String,
+        identity: String,
+        buckets: List<Pair<String, Double>>,
+        status: ChallengeStanding.Status = ChallengeStanding.Status.active,
+    ) = ChallengeStanding(
+        buckets = buckets.map { (start, v) -> ChartDataBucket(bucketStart = start, value = v) },
+        displayName = name,
+        identityBaseUrl = identity,
+        lastUpdated = null,
+        stale = false,
+        status = status,
+        total = buckets.sumOf { it.second },
+    )
+
+    // --- URLs -------------------------------------------------------------
+
+    @Test
+    fun `parseChallengeUrl splits base, username and slug`() {
+        val parsed = parseChallengeUrl("https://aurboda.net/u/fiddur/august-steppers")
+        assertEquals("https://aurboda.net", parsed?.base)
+        assertEquals("fiddur", parsed?.username)
+        assertEquals("august-steppers", parsed?.slug)
+    }
+
+    @Test
+    fun `parseChallengeUrl keeps an instance sub-path and ignores a trailing slash`() {
+        val parsed = parseChallengeUrl("https://host.example/aurboda/u/anna/walk/")
+        assertEquals("https://host.example/aurboda", parsed?.base)
+        assertEquals("anna", parsed?.username)
+        assertEquals("walk", parsed?.slug)
+    }
+
+    @Test
+    fun `parseChallengeUrl rejects non-challenge URLs`() {
+        assertNull(parseChallengeUrl("https://aurboda.net/challenges"))
+        assertNull(parseChallengeUrl("https://aurboda.net/u/fiddur"))
+        assertNull(parseChallengeUrl("/u/fiddur/slug"))
+    }
+
+    @Test
+    fun `challengeDeepLinkPath is site-relative on the own instance and absolute elsewhere`() {
+        assertEquals(
+            "/u/fiddur/august-steppers",
+            challengeDeepLinkPath("https://aurboda.net/", "https://aurboda.net/u/fiddur/august-steppers"),
+        )
+        assertEquals(
+            "https://other.example/u/anna/walk",
+            challengeDeepLinkPath("https://aurboda.net", "https://other.example/u/anna/walk"),
+        )
+        // Signed out: still an absolute link rather than a wrong relative one.
+        assertEquals("https://aurboda.net/u/fiddur/x", challengeDeepLinkPath(null, "https://aurboda.net/u/fiddur/x"))
+    }
+
+    // --- Picks + summary --------------------------------------------------
+
+    @Test
+    fun `challengePicks lists hosted first, then active joined only`() {
+        val picks =
+            challengePicks(
+                hosted = listOf(hosted("mine", "https://aurboda.net/u/me/mine")),
+                joined =
+                    listOf(
+                        joined("theirs", "https://other.example/u/anna/theirs"),
+                        joined("left", "https://other.example/u/anna/left", ChallengeParticipation.Status.withdrawn),
+                    ),
+            )
+        assertEquals(listOf("mine", "theirs"), picks.map { it.name })
+        assertEquals(listOf(true, false), picks.map { it.hosted })
+        assertEquals("steps · sum", picks[0].detail)
+    }
+
+    @Test
+    fun `findChallengeSummary matches hosted or joined by URL, ignoring trailing slashes`() {
+        val hostedList = listOf(hosted("mine", "https://aurboda.net/u/me/mine"))
+        val joinedList = listOf(joined("theirs", "https://other.example/u/anna/theirs"))
+        assertEquals("mine", findChallengeSummary("https://aurboda.net/u/me/mine/", hostedList, joinedList)?.name)
+        assertEquals("theirs", findChallengeSummary("https://other.example/u/anna/theirs", hostedList, joinedList)?.name)
+        assertNull(findChallengeSummary("https://aurboda.net/u/me/gone", hostedList, joinedList))
+        val s = findChallengeSummary("https://aurboda.net/u/me/mine", hostedList, joinedList)!!
+        assertEquals("steps", s.unit)
+        assertEquals(parseInstantMillis("2026-07-31T22:00:00.000Z"), s.startMillis)
+    }
+
+    // --- Series -----------------------------------------------------------
+
+    @Test
+    fun `inferBucketMillis is the smallest gap between bucket starts, defaulting to a day`() {
+        val daily =
+            standing(
+                "a",
+                "https://x/u/a",
+                listOf("2026-08-01T00:00:00Z" to 1.0, "2026-08-03T00:00:00Z" to 1.0, "2026-08-02T00:00:00Z" to 1.0),
+            )
+        assertEquals(DAY_MILLIS, inferBucketMillis(listOf(daily)))
+        val hourly = standing("b", "https://x/u/b", listOf("2026-08-01T00:00:00Z" to 1.0, "2026-08-01T01:00:00Z" to 1.0))
+        assertEquals(60L * 60 * 1000, inferBucketMillis(listOf(daily, hourly)))
+        assertEquals(DAY_MILLIS, inferBucketMillis(listOf(standing("c", "https://x/u/c", listOf("2026-08-01T00:00:00Z" to 5.0)))))
+        assertEquals(DAY_MILLIS, inferBucketMillis(emptyList()))
+    }
+
+    @Test
+    fun `cumulativeSeries starts at zero on the start line and accumulates at bucket ends`() {
+        val start = parseInstantMillis("2026-07-31T22:00:00Z")
+        val s =
+            standing(
+                "a",
+                "https://x/u/a",
+                listOf("2026-08-02T00:00:00Z" to 3000.0, "2026-08-01T00:00:00Z" to 5000.0),
+            )
+        val series = cumulativeSeries(s, 0xFF123456.toInt(), start, DAY_MILLIS)
+        assertEquals(0xFF123456.toInt(), series.color)
+        assertEquals(listOf(0.0, 5000.0, 8000.0), series.points.map { it.value })
+        assertEquals(start, series.points[0].timeMillis)
+        assertEquals(parseInstantMillis("2026-08-02T00:00:00Z"), series.points[1].timeMillis)
+        assertEquals(parseInstantMillis("2026-08-03T00:00:00Z"), series.points[2].timeMillis)
+    }
+
+    // --- Leaderboard ------------------------------------------------------
+
+    @Test
+    fun `leaderboard ranks active members with the web palette and marks the signed-in user`() {
+        val rows =
+            leaderboard(
+                listOf(
+                    standing("delvoriah", "https://aurboda.net/u/delvoriah", listOf("2026-08-01T00:00:00Z" to 138989.0)),
+                    standing("fiddur", "https://aurboda.net/u/fiddur/", listOf("2026-08-01T00:00:00Z" to 120055.0)),
+                    standing("gone", "https://aurboda.net/u/gone", emptyList(), ChallengeStanding.Status.withdrawn),
+                ),
+                myIdentityUrl("https://aurboda.net/", "fiddur"),
+            )
+        assertEquals(listOf(1, 2), rows.map { it.rank })
+        assertEquals(listOf(CHALLENGE_MEMBER_COLORS[0], CHALLENGE_MEMBER_COLORS[1]), rows.map { it.color })
+        assertEquals(listOf(false, true), rows.map { it.isMe })
+        // Grouping separator is locale-specific; the digits and the fact that it is grouped are not.
+        val formatted = formatChallengeTotal(rows[0].total)
+        assertEquals("138989", formatted.filter { it.isDigit() })
+        assertTrue(formatted.length > 6)
+    }
+
+    @Test
+    fun `visibleRows keeps the top rows but swaps the user in when they would be cut`() {
+        val rows =
+            (1..6).map { i ->
+                LeaderboardRow(rank = i, name = "m$i", color = challengeMemberColor(i - 1), total = 100.0 - i, isMe = i == 5)
+            }
+        assertEquals(listOf(1, 2, 5), visibleRows(rows, 3).map { it.rank })
+        assertEquals(listOf(1, 2, 3, 4, 5), visibleRows(rows, 5).map { it.rank })
+        assertEquals((1..6).toList(), visibleRows(rows, 10).map { it.rank })
+        assertTrue(visibleRows(rows, 0).isEmpty())
+        val nobodyIsMe = rows.map { it.copy(isMe = false) }
+        assertEquals(listOf(1, 2, 3), visibleRows(nobodyIsMe, 3).map { it.rank })
+    }
+
+    // --- Layout + text ----------------------------------------------------
+
+    @Test
+    fun `planChallengeWidgetLayout gives a 2x2 cell two rows and a small chart, and grows with height`() {
+        val small = planChallengeWidgetLayout(widthDp = 110f, heightDp = 110f, memberCount = 5)
+        assertEquals(2, small.rowCount)
+        assertTrue(small.chartHeightDp >= ChallengeWidgetGeometry.MIN_CHART)
+        assertEquals(110 - 2 * ChallengeWidgetGeometry.PADDING, small.chartWidthDp)
+        assertFalse(small.showRank)
+
+        val tall = planChallengeWidgetLayout(widthDp = 110f, heightDp = 250f, memberCount = 5)
+        assertEquals(5, tall.rowCount)
+        assertTrue(tall.chartHeightDp > small.chartHeightDp)
+
+        // Never more rows than members; the spare height goes to the chart.
+        val two = planChallengeWidgetLayout(widthDp = 250f, heightDp = 250f, memberCount = 2)
+        assertEquals(2, two.rowCount)
+        assertTrue(two.chartHeightDp > tall.chartHeightDp)
+        assertTrue(two.showRank)
+
+        // At least one row when there is anyone to show, even if it squeezes the chart.
+        assertEquals(1, planChallengeWidgetLayout(widthDp = 110f, heightDp = 70f, memberCount = 3).rowCount)
+        assertEquals(0, planChallengeWidgetLayout(widthDp = 110f, heightDp = 110f, memberCount = 0).rowCount)
+    }
+
+    @Test
+    fun `challengeMetaLine describes where the challenge is in its window`() {
+        val start = parseInstantMillis("2026-07-31T22:00:00Z")
+        val end = parseInstantMillis("2026-08-31T22:00:00Z")
+        assertEquals("steps · 14 days left", challengeMetaLine("steps", start, end, parseInstantMillis("2026-08-18T10:00:00Z")))
+        assertEquals("steps · last day", challengeMetaLine("steps", start, end, parseInstantMillis("2026-08-31T10:00:00Z")))
+        assertEquals("steps · ended", challengeMetaLine("steps", start, end, end))
+        assertEquals("steps · starts in 3 days", challengeMetaLine("steps", start, end, parseInstantMillis("2026-07-29T10:00:00Z")))
+        assertEquals("steps · starts tomorrow", challengeMetaLine("steps", start, end, parseInstantMillis("2026-07-31T10:00:00Z")))
+    }
+
+    @Test
+    fun `challengeDateRange renders the inclusive window in the challenge timezone`() {
+        // Midnight Stockholm = 22:00Z the day before; the exclusive end steps back to Aug 31.
+        assertEquals("Aug 1 – Aug 31", challengeDateRange("2026-07-31T22:00:00Z", "2026-08-31T22:00:00Z", "Europe/Stockholm", Locale.ENGLISH))
+        assertEquals("Jul 31 – Aug 31", challengeDateRange("2026-07-31T22:00:00Z", "2026-08-31T22:00:00Z", "UTC", Locale.ENGLISH))
+        // An unknown zone must not throw.
+        assertFalse(challengeDateRange("2026-07-31T22:00:00Z", "2026-08-31T22:00:00Z", "Not/AZone", Locale.ENGLISH).isEmpty())
+    }
+}

--- a/apps/web/src/pages/Challenges/PublicChallenge.tsx
+++ b/apps/web/src/pages/Challenges/PublicChallenge.tsx
@@ -151,6 +151,12 @@ export function PublicChallenge({
             <tr key={s.identity_base_url}>
               <td>{i + 1}</td>
               <td>
+                {/* Same palette index as the member's line in the race chart above. */}
+                <span
+                  aria-hidden="true"
+                  class="challenge-member-color"
+                  style={{ background: COLORS[i % COLORS.length] }}
+                />
                 {s.display_name} <span class="challenge-member-host">· {shortHost(s.identity_base_url)}</span>
               </td>
               <td>{Math.round(s.total).toLocaleString()}</td>

--- a/apps/web/src/pages/Challenges/style.css
+++ b/apps/web/src/pages/Challenges/style.css
@@ -177,6 +177,17 @@
   color: #6b7280;
 }
 
+.challenge-member-color {
+  display: inline-block;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+
 .challenge-member-host,
 .challenge-member-updated {
   color: #9ca3af;

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -10,13 +10,13 @@ implementations of the same UI.
 A bottom navigation bar (`ui/screens/MainScreen.kt`, tabs in `AppState.kt`'s
 `MainTab`) hosts five tabs:
 
-| Tab  | Kind     | Why                                                                     |
-| ---- | -------- | ----------------------------------------------------------------------- |
-| Home | Embedded | Web `/` (the dashboard); the default tab on launch                      |
-| Add  | Native   | Native date/time pickers, offline entry queue                           |
-| Feed | Embedded | Web `/feed`                                                             |
-| Sync | Native   | Health Connect permissions, background sync management                  |
-| More | Hub      | Native list of everything else (`ui/screens/MoreScreen.kt`)             |
+| Tab  | Kind     | Why                                                         |
+| ---- | -------- | ----------------------------------------------------------- |
+| Home | Embedded | Web `/` (the dashboard); the default tab on launch          |
+| Add  | Native   | Native date/time pickers, offline entry queue               |
+| Feed | Embedded | Web `/feed`                                                 |
+| Sync | Native   | Health Connect permissions, background sync management      |
+| More | Hub      | Native list of everything else (`ui/screens/MoreScreen.kt`) |
 
 There are far more web pages than fit on a bottom bar, so the **More** tab is a
 hub (`MoreScreen.kt`, `moreGroups`): a grouped list where each entry opens the
@@ -105,3 +105,38 @@ the external browser (via `ACTION_VIEW`); same-origin links stay in the WebView.
 The decision is a pure, unit-tested helper: `ui/screens/WebLink.kt`
 (`isExternalLink`). Non-http(s) schemes (`mailto:`, `tel:`, …) are treated as
 external.
+
+## Home-screen widgets
+
+Two `AppWidgetProvider`s live in `widget/`:
+
+- **HR Zones** (`HrZoneWidgetProvider` + `GoalsWidgetService`): the goal
+  progress bars, see `docs/GOAL_WIDGET.md`. Tapping it opens the Goals page.
+- **Challenge** (`ChallengeWidgetProvider`, min 2×2, resizable): the race chart
+  and leaderboard of **one** challenge, hosted or joined. When the widget is
+  placed the launcher opens `ChallengeWidgetConfigActivity` (a Compose list of
+  the user's hosted + active joined challenges, from `GET /challenges` and
+  `GET /challenges/participations/mine`); the pick is stored per widget id in
+  SharedPreferences (`ChallengeWidgetPrefs.kt`). Rendering — including the
+  network fetch — runs in `ChallengeWidgetWorker` (WorkManager, unique
+  `APPEND_OR_REPLACE`), enqueued by the provider's `onUpdate`/resize, the config
+  screen, and after every sync; the receiver itself never blocks. Data comes from
+  the user's own instance for the challenge itself (name, unit, window — so a
+  rename or a left challenge shows) and from the **hosting** instance's public
+  `GET /public/:username/:slug/standings` (discovered via `/.well-known/aurboda`
+  like a federated join, `ChallengeApi.kt`). The chart is a Canvas bitmap
+  (`ChallengeChart.kt`) — a widget can't host a WebView — with the same member
+  palette as the web page; the leaderboard rows are added with
+  `RemoteViews.addView`, as many as fit for the launcher-reported size
+  (`planChallengeWidgetLayout`), always keeping the signed-in user's row. All
+  the pure logic (series, rows, layout, texts) is in `ChallengeWidgetModel.kt`
+  and unit-tested. Tapping the widget deep-links to `/u/<owner>/<slug>` (or the
+  absolute URL for a challenge on another instance) in the More tab.
+
+Widget taps and notification taps reach `MainActivity` as `EXTRA_OPEN_TAB` /
+`EXTRA_MORE_PATH` extras (`deepLinkFrom` in `AppState.kt`). On a cold start they
+pick the initial tab/page; because the activity is `singleTop`, a tap while the
+app is running arrives in `onNewIntent` and navigates the running app to the same
+place (`AppState.open`). `MoreDestination.Web` accepts either a site path or an
+absolute URL (`embeddedPageUrl`), so a joined challenge hosted elsewhere opens
+embedded too — its own in-page links open in the browser as any external link.

--- a/docs/features/challenges.md
+++ b/docs/features/challenges.md
@@ -107,12 +107,22 @@ the backend directly need no extra config.
   quick-sets, public/unlisted), copy its link, delete it; see challenges you've
   joined; and **join by URL** (paste any challenge link — local or remote).
 - **View** at `/u/<username>/<slug>`: a cumulative **race chart** (one line per
-  member) + a **leaderboard** (rank, `@member · host`, total, freshness). This is
+  member) + a **leaderboard** (rank, colour dot matching the member's chart line,
+  `@member · host`, total, freshness). This is
   the same `/u/:username/:slug` page as shared dashboards — the server returns a
   `type` and the page renders the right view.
 - **Join buttons:** logged-in users on the host instance get a one-click **Join**;
   anyone can **Join from another instance** (enter your Aurboda host → you're sent
   to your own instance's `/challenges/join`, which does the federated join).
+
+## Android widget
+
+The Android app has a home-screen **Challenge widget** (2×2 and up): pick a
+hosted or joined challenge when placing it and it shows the race chart and
+leaderboard (same member colours as the web page), refreshed after each sync;
+tapping it opens the challenge in the app. Standings are read from the hosting
+instance's public standings endpoint, so it works for challenges hosted elsewhere
+too. See `docs/android-app.md` → _Home-screen widgets_.
 
 ## API surface (authed, owner/joiner)
 

--- a/packages/api-spec/src/openapi.ts
+++ b/packages/api-spec/src/openapi.ts
@@ -12,6 +12,12 @@ import { createDocument } from 'zod-openapi'
 
 import { activitiesResponseSchema } from './schemas/activities.ts'
 import { loginBodySchema, loginResponseSchema } from './schemas/admin.ts'
+import {
+  challengeParticipationsResponseSchema,
+  challengesResponseSchema,
+  challengeStandingsResponseSchema,
+  wellKnownAurbodaSchema,
+} from './schemas/challenges.ts'
 // Import all schemas
 import { dateOnlySchema, iso8601DateTimeSchema, metricTypeSchema } from './schemas/common.ts'
 import { dailySummaryResponseSchema } from './schemas/daily-summary.ts'
@@ -84,6 +90,10 @@ const deleteResponseSchema = z
 
 const openApiDocument = createDocument({
   components: {
+    // Served at the instance root (`/.well-known/aurboda`), outside the `/api`
+    // server base, so it has no path entry — the model is registered so federation
+    // clients (the Android challenge widget) get a generated type for it.
+    schemas: { WellKnownAurboda: wellKnownAurbodaSchema },
     securitySchemes: {
       bearerAuth: {
         bearerFormat: 'JWT',
@@ -109,6 +119,59 @@ const openApiDocument = createDocument({
   },
   openapi: '3.1.0',
   paths: {
+    // --- Challenges ---
+    '/challenges': {
+      get: {
+        description: 'List the challenges hosted by the authenticated user.',
+        responses: {
+          200: {
+            content: { 'application/json': { schema: challengesResponseSchema } },
+            description: 'Successful response',
+          },
+        },
+        security: [{ bearerAuth: [] }],
+        summary: 'List my challenges',
+        tags: ['Challenges'],
+      },
+    },
+    '/challenges/participations/mine': {
+      get: {
+        description: 'List the challenges the authenticated user has joined (possibly on other instances).',
+        responses: {
+          200: {
+            content: { 'application/json': { schema: challengeParticipationsResponseSchema } },
+            description: 'Successful response',
+          },
+        },
+        security: [{ bearerAuth: [] }],
+        summary: 'List my challenge participations',
+        tags: ['Challenges'],
+      },
+    },
+    '/public/{username}/{slug}/standings': {
+      get: {
+        description:
+          "Public standings of a challenge hosted at `/u/{username}/{slug}`: each active member's bucketed series and total. No authentication.",
+        requestParams: {
+          path: z.object({
+            slug: z.string().meta({ description: 'Challenge slug' }),
+            username: z.string().meta({ description: 'Host username' }),
+          }),
+        },
+        responses: {
+          200: {
+            content: { 'application/json': { schema: challengeStandingsResponseSchema } },
+            description: 'Successful response',
+          },
+          404: {
+            content: { 'application/json': { schema: errorResponseSchema } },
+            description: 'Challenge not found',
+          },
+        },
+        summary: 'Get public challenge standings',
+        tags: ['Challenges'],
+      },
+    },
     // --- Activities ---
     '/activities': {
       get: {
@@ -925,6 +988,7 @@ const openApiDocument = createDocument({
     { description: 'Time series health metrics', name: 'Metrics' },
     { description: 'Daily and period summaries', name: 'Summary' },
     { description: 'Sleep, exercise, meditation sessions', name: 'Activities' },
+    { description: 'Federated challenges: hosted, joined, and public standings', name: 'Challenges' },
     { description: 'Named and detected locations', name: 'Locations' },
     { description: 'RescueTime productivity data', name: 'Productivity' },
     { description: 'User settings and preferences', name: 'Settings' },


### PR DESCRIPTION
## Summary

- **Web**: the public challenge leaderboard shows each member's chart colour as a dot before their name (same palette index as their race-chart line).
- **Android**: new home-screen **Challenge widget** (min 2×2, resizable). Placing it opens a picker of the user's hosted + active joined challenges; the widget shows that challenge's race chart (Canvas bitmap, same member palette as the web) and a leaderboard sized to the widget (always keeping the signed-in user's row), refreshed after every sync. Tapping it opens the challenge page in the app.
- **Deep links while running**: `MainActivity` now follows widget/notification deep links from `onNewIntent` too (previously only on a cold start), so the widget tap always lands on the challenge. `MoreDestination.Web` accepts absolute URLs so a challenge hosted on another instance opens embedded as well.
- **api-spec**: `/challenges`, `/challenges/participations/mine`, `/public/{username}/{slug}/standings` and `WellKnownAurboda` are registered in the OpenAPI doc so the Kotlin models exist for the widget.
- Docs: `docs/android-app.md` (Home-screen widgets, deep links), `docs/features/challenges.md`.

## Design notes

- Rendering (incl. network) runs in a WorkManager job (`ChallengeWidgetWorker`, unique `APPEND_OR_REPLACE`); the receiver never blocks.
- The challenge itself (name/unit/window) comes from the user's own instance; standings from the **hosting** instance's public standings endpoint (well-known discovery for remote hosts), so joined remote challenges work.
- Pure logic (URL parsing, series, leaderboard rows, layout per widget size, texts) is in `ChallengeWidgetModel.kt` and unit-tested; the chart and API functions have tests too.

## Test plan

- [x] `pnpm --filter aurboda-web check`, `pnpm --filter @aurboda/api-spec check`
- [x] `./gradlew compileDebugKotlin`, `./gradlew testDebugUnitTest` (269 tests, incl. 22 new)
- [x] Widget rendered under Robolectric at 2×2 / 4×2 / 3×3 sizes to eyeball the layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxakEjLFANVr46YgL8uj29
