### PR TITLE
feat(feed): personal message, native stat grid, activity-date line (#995, #997, #998)

### DIFF
--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -113,6 +113,26 @@ describe('Feed posts integration', () => {
     expect((await getFeedPostById(user, created.id))?.image_token).toBe(created.image_token)
   })
 
+  test('stores, patches, and clears the personal message (#995)', async () => {
+    const user = getTestUser()
+    // Omitted on create → NULL.
+    const bare = await createFeedPost(user, postInput())
+    expect(bare.message).toBeNull()
+
+    const created = await createFeedPost(user, postInput({ message: 'Felt great,\nnegative splits!' }))
+    expect(created.message).toBe('Felt great,\nnegative splits!')
+    expect((await getFeedPostById(user, created.id))?.message).toBe('Felt great,\nnegative splits!')
+
+    // An undefined patch field leaves the message untouched…
+    const untouched = await updateFeedPost(user, created.id, { visibility: 'unlisted' })
+    expect(untouched?.message).toBe('Felt great,\nnegative splits!')
+    // …a string replaces it, and null clears it.
+    const replaced = await updateFeedPost(user, created.id, { message: 'Actually just ok' })
+    expect(replaced?.message).toBe('Actually just ok')
+    const cleared = await updateFeedPost(user, created.id, { message: null })
+    expect(cleared?.message).toBeNull()
+  })
+
   test('lists posts newest-first', async () => {
     const user = getTestUser()
     const first = await createFeedPost(user, postInput())

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -26,6 +26,8 @@ export interface FeedPostRecord {
   include_chart: boolean
   /** Stored article payload (title + default window + blocks); null for `activity` posts. */
   article: ArticleContent | null
+  /** The author's personal message (plain text), or null when none was shared. */
+  message: string | null
   /** Unguessable capability token for `followers`-only image URLs (see schema). */
   image_token: string
   created_at: Date
@@ -39,6 +41,8 @@ export interface FeedPostInput {
   visibility: FeedVisibility
   include_map: boolean
   include_chart: boolean
+  /** The author's personal message; omitted/undefined stores NULL. */
+  message?: string | null
 }
 
 /** Input for creating an `article` post (no activity anchor / shared metrics). */
@@ -55,10 +59,12 @@ export interface FeedPostPatch {
   include_chart?: boolean
   /** Replacement article payload (whole `article` JSONB), for editing an article post. */
   article?: ArticleContent
+  /** Replacement personal message; `null` clears it, `undefined` leaves it unchanged. */
+  message?: string | null
 }
 
 const FEED_POST_COLUMNS =
-  'id, kind, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, article, image_token, created_at, updated_at'
+  'id, kind, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, article, message, image_token, created_at, updated_at'
 
 interface FeedPostRow {
   id: string
@@ -71,6 +77,7 @@ interface FeedPostRow {
   include_chart: boolean
   // pg parses a jsonb column to its JS value on read (null for `activity` posts).
   article: ArticleContent | null
+  message: string | null
   image_token: string
   created_at: Date
   updated_at: Date
@@ -82,8 +89,8 @@ export const createFeedPost = async (user: string, input: FeedPostInput): Promis
   const result = await query<FeedPostRow>(
     user,
     `INSERT INTO feed_posts
-       (activity_id, included_metrics, series_metrics, visibility, include_map, include_chart)
-     VALUES ($1, $2, $3, $4, $5, $6)
+       (activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, message)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
      RETURNING ${FEED_POST_COLUMNS}`,
     [
       input.activity_id,
@@ -92,6 +99,7 @@ export const createFeedPost = async (user: string, input: FeedPostInput): Promis
       input.visibility,
       input.include_map,
       input.include_chart,
+      input.message ?? null,
     ],
   )
   return mapFeedPost(result.rows[0])
@@ -194,6 +202,7 @@ export const updateFeedPost = async (
   if (patch.include_map !== undefined) set('include_map', patch.include_map)
   if (patch.include_chart !== undefined) set('include_chart', patch.include_chart)
   if (patch.article !== undefined) set('article', JSON.stringify(patch.article))
+  if (patch.message !== undefined) set('message', patch.message)
 
   if (sets.length === 0) return getFeedPostById(user, id)
 

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -34,7 +34,7 @@ import {
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
-import { serializeFeedPost } from '../services/feed.ts'
+import { normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
 import { serializeFollower } from '../services/followers.ts'
 import { serializeFollowing } from '../services/following.ts'
 import { getTimelinePage } from '../services/timeline.ts'
@@ -77,6 +77,7 @@ export const registerFeedTools = (
         include_chart: body.include_chart,
         include_map: body.include_map,
         included_metrics: body.included_metrics,
+        message: normalizeFeedMessage(body.message) ?? null,
         series_metrics: body.series_metrics,
         visibility: body.visibility,
       })
@@ -95,6 +96,7 @@ export const registerFeedTools = (
         include_chart: body.include_chart,
         include_map: body.include_map,
         included_metrics: body.included_metrics,
+        message: normalizeFeedMessage(body.message),
         series_metrics: body.series_metrics,
         visibility: body.visibility,
       })

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -34,6 +34,7 @@ const makePost = (overrides: Partial<FeedPostRecord> = {}): FeedPostRecord => ({
   include_map: true,
   included_metrics: [],
   kind: 'activity',
+  message: null,
   series_metrics: [],
   updated_at: new Date('2026-07-01T08:00:00Z'),
   visibility: 'public',

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -41,7 +41,7 @@ import {
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
-import { serializeFeedPost } from '../services/feed.ts'
+import { normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
 import { getTimelinePage } from '../services/timeline.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
@@ -159,6 +159,7 @@ export const createFeedRouter = (
         include_chart: req.body.include_chart,
         include_map: req.body.include_map,
         included_metrics: req.body.included_metrics,
+        message: normalizeFeedMessage(req.body.message) ?? null,
         series_metrics: req.body.series_metrics,
         visibility: req.body.visibility,
       })
@@ -265,6 +266,7 @@ export const createFeedRouter = (
         include_chart: req.body.include_chart,
         include_map: req.body.include_map,
         included_metrics: req.body.included_metrics,
+        message: normalizeFeedMessage(req.body.message),
         series_metrics: req.body.series_metrics,
         visibility: req.body.visibility,
       })

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -125,6 +125,7 @@ export const socialTables: Record<string, string> = {
       include_map       BOOLEAN NOT NULL DEFAULT false,
       include_chart     BOOLEAN NOT NULL DEFAULT false,
       article           JSONB,
+      message           TEXT,
       image_token       TEXT NOT NULL DEFAULT gen_random_uuid()::text,
       created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -134,6 +135,11 @@ export const socialTables: Record<string, string> = {
   feed_posts_article_columns: `
     ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS kind VARCHAR(12) NOT NULL DEFAULT 'activity';
     ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS article JSONB;
+  `,
+  // The author's personal message on a post (plain text; #995). Additive for
+  // pre-existing tables (idempotent).
+  feed_posts_message_column: `
+    ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS message TEXT;
   `,
   // `idx_feed_posts_series` is a GIN index over the shared-series set — the hot
   // path for the public series endpoint's `metric = ANY(series_metrics)` check.

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -24,9 +24,10 @@ import { Create, Delete, Image, Note, Tombstone, Update } from '@fedify/fedify/v
 
 import type { FeedPostRecord } from '../../db/index.ts'
 
+import { getSettings } from '../settings.ts'
 import { articleImageAttachments, renderArticleContentHtml } from './article-object.ts'
 import { resolveActivityScalars } from './feed-activity.ts'
-import { addressingFor, feedPostContent, isPubliclyVisible } from './object.ts'
+import { addressingFor, feedPostContent, formatActivityWindow, isPubliclyVisible } from './object.ts'
 import { dateToTemporalInstant } from './temporal-interop.ts'
 
 /**
@@ -51,6 +52,8 @@ export interface DeliverablePost {
   id: string
   included_metrics: string[]
   visibility: FeedVisibility
+  /** The author's personal message (plain text); null/undefined = none shared. */
+  message?: string | null
   created_at: Date
   /** Last-edited time; makes each `Update` activity id unique (see `buildFeedUpdate`). */
   updated_at: Date
@@ -132,7 +135,17 @@ export const buildFeedNote = async (
   apiBaseUrl: string,
 ): Promise<Note> => {
   const scalars = await resolveActivityScalars(user, activity, post.included_metrics)
-  const { content, name } = feedPostContent(activity.title, activity.activity_type, scalars)
+  // The activity-date line renders in the author's device timezone (like the
+  // article block images); unknown/invalid falls back to UTC inside the formatter.
+  const settings = await getSettings(user).catch(() => null)
+  const { content, name } = feedPostContent(activity.title, activity.activity_type, scalars, {
+    message: post.message ?? undefined,
+    windowLabel: formatActivityWindow(
+      activity.start_time,
+      activity.end_time,
+      settings?.device_timezone ?? undefined,
+    ),
+  })
   const actorUri = ctx.getActorUri(user)
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))

--- a/apps/backend/src/services/activitypub/object.test.ts
+++ b/apps/backend/src/services/activitypub/object.test.ts
@@ -6,6 +6,7 @@ import {
   type BuildCreateInput,
   buildCreateExercise,
   feedPostContent,
+  formatActivityWindow,
 } from './object.ts'
 
 const base: BuildCreateInput = {
@@ -62,11 +63,36 @@ describe('buildCreateExercise', () => {
     ])
   })
 
-  test('content is a bold title headline with the shared scalars on their own line', () => {
+  test('content is a bold title headline, the activity-date line, and one stat per line', () => {
     const c = buildCreateExercise(base)
     expect(c.object.content).toBe(
-      '<p><strong>Morning run</strong></p><p>Distance 8.2 km · Avg HR 148 bpm · Hr zone minutes z2 22, z3 11</p>',
+      '<p><strong>Morning run</strong></p>' +
+        '<p>Wed, 1 Jul 2026, 06:30–07:11</p>' +
+        '<p>Distance 8.2 km<br>Avg HR 148 bpm<br>Hr zone minutes z2 22, z3 11</p>',
     )
+  })
+
+  test('a personal message renders between the headline and the date line, and rides aurboda:message', () => {
+    const c = buildCreateExercise({ ...base, message: 'Felt great,\nnegative splits!' })
+    expect(c.object.content).toBe(
+      '<p><strong>Morning run</strong></p>' +
+        '<p>Felt great,<br>negative splits!</p>' +
+        '<p>Wed, 1 Jul 2026, 06:30–07:11</p>' +
+        '<p>Distance 8.2 km<br>Avg HR 148 bpm<br>Hr zone minutes z2 22, z3 11</p>',
+    )
+    expect(c.object['aurboda:message']).toBe('Felt great,\nnegative splits!')
+  })
+
+  test('no aurboda:message and no message paragraph for a blank message', () => {
+    const c = buildCreateExercise({ ...base, message: '   ' })
+    expect(c.object['aurboda:message']).toBeUndefined()
+    expect(c.object.content).not.toContain('<p> ')
+  })
+
+  test('the date line renders in the given timezone', () => {
+    const c = buildCreateExercise({ ...base, timeZone: 'Europe/Stockholm' })
+    // 06:30Z–07:11Z is 08:30–09:11 CEST.
+    expect(c.object.content).toContain('<p>Wed, 1 Jul 2026, 08:30–09:11</p>')
   })
 
   test('aurboda:metrics carries the machine-readable shared scalars only', () => {
@@ -116,7 +142,10 @@ describe('buildCreateExercise', () => {
 
   test('escapes HTML in the title for the fallback content', () => {
     const c = buildCreateExercise({ ...base, scalars: [], title: 'Run <b>x</b> & "go"' })
-    expect(c.object.content).toBe('<p><strong>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</strong></p>')
+    expect(c.object.content).toBe(
+      '<p><strong>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</strong></p>' +
+        '<p>Wed, 1 Jul 2026, 06:30–07:11</p>',
+    )
   })
 
   test('uses publishedAt for the AS2 published times, keeping the workout time in aurboda:startTime', () => {
@@ -138,15 +167,51 @@ describe('buildCreateExercise', () => {
   })
 })
 
+describe('formatActivityWindow', () => {
+  test('same-day window collapses the end to its time', () => {
+    expect(formatActivityWindow('2026-08-02T13:44:00Z', '2026-08-02T16:12:00Z', 'Europe/Stockholm')).toBe(
+      'Sun, 2 Aug 2026, 15:44–18:12',
+    )
+  })
+
+  test('cross-day window spells out both ends', () => {
+    expect(formatActivityWindow('2026-08-02T22:30:00Z', '2026-08-03T06:10:00Z', 'UTC')).toBe(
+      'Sun, 2 Aug 2026, 22:30 – Mon, 3 Aug 2026, 06:10',
+    )
+  })
+
+  test('open-ended activity renders only the start', () => {
+    expect(formatActivityWindow('2026-08-02T13:44:00Z', undefined, 'UTC')).toBe('Sun, 2 Aug 2026, 13:44')
+  })
+
+  test('an invalid timezone falls back to UTC instead of throwing', () => {
+    expect(formatActivityWindow('2026-08-02T13:44:00Z', undefined, 'Not/AZone')).toBe(
+      'Sun, 2 Aug 2026, 13:44',
+    )
+  })
+})
+
 describe('feedPostContent', () => {
-  test('renders a bold headline with stats below and a humanized duration', () => {
+  test('renders a bold headline with one stat per line and a humanized duration', () => {
     const { content } = feedPostContent('Evening qigong', 'yoga', [
       { key: 'duration', label: 'Duration', unit: 'seconds', value: 642 },
       { key: 'heart_rate_avg', label: 'Avg HR', unit: 'bpm', value: 76 },
       { key: 'calories', label: 'Calories', unit: 'kcal', value: 9 },
     ])
     expect(content).toBe(
-      '<p><strong>Evening qigong</strong></p><p>Duration 10m 42s · Avg HR 76 bpm · Calories 9 kcal</p>',
+      '<p><strong>Evening qigong</strong></p><p>Duration 10m 42s<br>Avg HR 76 bpm<br>Calories 9 kcal</p>',
+    )
+  })
+
+  test('escapes HTML in the message and preserves its linebreaks as <br>', () => {
+    const { content } = feedPostContent('Row', 'rowing', [], {
+      message: 'So <b>good</b>\n& calm',
+      windowLabel: 'Sun, 2 Aug 2026, 15:44–18:12',
+    })
+    expect(content).toBe(
+      '<p><strong>Row</strong></p>' +
+        '<p>So &lt;b&gt;good&lt;/b&gt;<br>&amp; calm</p>' +
+        '<p>Sun, 2 Aug 2026, 15:44–18:12</p>',
     )
   })
 

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -55,6 +55,10 @@ export interface BuildCreateInput {
    */
   publishedAt?: string
   title?: string
+  /** The author's personal message for the post (plain text), if any. */
+  message?: string
+  /** IANA timezone for the human-readable activity-date line (defaults to UTC). */
+  timeZone?: string
   /** Resolved scalar summaries for the shared `included_metrics`. */
   scalars: ScalarMetric[]
   /** Metric keys whose series were explicitly shared (drive `aurboda:series`). */
@@ -112,24 +116,77 @@ const formatScalar = ({ key, value, unit, label }: ScalarMetric): string => {
 }
 
 /**
+ * Format one date-time for the activity-date line, in the author's timezone
+ * (fallback UTC when unset/invalid): `Sun 2 Aug 2026, 15:44`.
+ */
+const formatWindowInstant = (iso: string | Date, timeZone: string | undefined, dateOnly = false) => {
+  const date = typeof iso === 'string' ? new Date(iso) : iso
+  const options: Intl.DateTimeFormatOptions = dateOnly
+    ? { day: 'numeric', month: 'short', weekday: 'short', year: 'numeric' }
+    : {
+        day: 'numeric',
+        hour: '2-digit',
+        hour12: false,
+        minute: '2-digit',
+        month: 'short',
+        weekday: 'short',
+        year: 'numeric',
+      }
+  try {
+    return new Intl.DateTimeFormat('en-GB', { ...options, timeZone: timeZone ?? 'UTC' }).format(date)
+  } catch {
+    // An invalid stored timezone must never break content building.
+    return new Intl.DateTimeFormat('en-GB', { ...options, timeZone: 'UTC' }).format(date)
+  }
+}
+
+/**
+ * Human-readable line saying WHEN the activity happened (#998) — the post's AS2
+ * `published` stays the share time (timeline ordering), so the activity's own
+ * date must be visible in the content. Same-day windows collapse the end to its
+ * time (`Sun 2 Aug 2026, 15:44–18:12`); cross-day windows spell out both ends.
+ */
+export const formatActivityWindow = (
+  start: string | Date,
+  end?: string | Date,
+  timeZone?: string,
+): string => {
+  const startLabel = formatWindowInstant(start, timeZone)
+  if (end === undefined) return startLabel
+  const sameDay = formatWindowInstant(start, timeZone, true) === formatWindowInstant(end, timeZone, true)
+  if (!sameDay) return `${startLabel} – ${formatWindowInstant(end, timeZone)}`
+  const endTime = formatWindowInstant(end, timeZone).split(', ').pop() ?? ''
+  return `${startLabel}–${endTime}`
+}
+
+/** Extra content parts beyond the title + scalars (all optional). */
+export interface FeedPostContentExtras {
+  /** The author's personal message (plain text; linebreaks become `<br>`). */
+  message?: string
+  /** Pre-formatted activity-date line (see `formatActivityWindow`). */
+  windowLabel?: string
+}
+
+/**
  * The human-readable status a plain fediverse client (Mastodon) renders: a bold
- * title headline with the shared scalars on their own line below, so it reads as
- * a workout post rather than one run-on sentence. `name` carries the same
- * headline. Shared by the AS2 object model and the Fedify delivery Note so both
- * read identically.
+ * title headline, the author's personal message (if any), the activity-date
+ * line, and the shared scalars one per line — structured paragraphs rather than
+ * one run-on `·`-joined sentence (#997). `name` carries the headline. Shared by
+ * the AS2 object model and the Fedify delivery Note so both read identically.
  */
 export const feedPostContent = (
   title: string | undefined,
   activityType: string,
   scalars: ScalarMetric[],
+  extras: FeedPostContentExtras = {},
 ): { name: string; content: string } => {
   const heading = title ?? `${prettifyKey(activityType)} activity`
-  const stats = scalars.map(formatScalar).join(' · ')
-  const headingHtml = `<p><strong>${escapeHtml(heading)}</strong></p>`
-  return {
-    content: stats ? `${headingHtml}<p>${escapeHtml(stats)}</p>` : headingHtml,
-    name: heading,
-  }
+  const parts = [`<p><strong>${escapeHtml(heading)}</strong></p>`]
+  const message = extras.message?.trim()
+  if (message) parts.push(`<p>${escapeHtml(message).replaceAll('\n', '<br>')}</p>`)
+  if (extras.windowLabel) parts.push(`<p>${escapeHtml(extras.windowLabel)}</p>`)
+  if (scalars.length > 0) parts.push(`<p>${scalars.map((s) => escapeHtml(formatScalar(s))).join('<br>')}</p>`)
+  return { content: parts.join(''), name: heading }
 }
 
 /**
@@ -197,7 +254,10 @@ export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
   const { to, cc } = addressingFor(input.visibility, followersUrl)
   const objectId = `${input.postId}/object`
 
-  const { content, name } = feedPostContent(input.title, input.activityType, input.scalars)
+  const { content, name } = feedPostContent(input.title, input.activityType, input.scalars, {
+    message: input.message,
+    windowLabel: formatActivityWindow(input.startTime, input.endTime, input.timeZone),
+  })
   // `published` is the share time (timeline ordering); the workout time lives in
   // `aurboda:startTime`.
   const published = input.publishedAt ?? input.startTime
@@ -220,6 +280,9 @@ export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
     url: input.postId,
   }
 
+  if (input.message !== undefined && input.message.trim() !== '') {
+    object['aurboda:message'] = input.message
+  }
   if (input.endTime) {
     object['aurboda:endTime'] = input.endTime
     object['aurboda:durationSeconds'] = Math.round(

--- a/apps/backend/src/services/feed-structured.integration.test.ts
+++ b/apps/backend/src/services/feed-structured.integration.test.ts
@@ -61,6 +61,7 @@ describe('resolveStructuredPost', () => {
       include_chart: false,
       include_map: false,
       included_metrics: ['heart_rate_avg', 'duration'],
+      message: 'Lovely morning!',
       series_metrics: ['heart_rate'],
       visibility: 'public',
     })
@@ -69,6 +70,8 @@ describe('resolveStructuredPost', () => {
     expect(structured).not.toBeNull()
     if (structured?.kind !== 'activity') throw new Error('expected an activity payload')
     expect(structured.activity_type).toBe('exercise')
+    // The author's personal message rides the structured payload (#995).
+    expect(structured.message).toBe('Lovely morning!')
     expect(structured.start_time).toBe(START.toISOString())
     expect(structured.end_time).toBe(END.toISOString())
     expect(structured.duration_seconds).toBe(2400)

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -270,6 +270,7 @@ export const resolveStructuredContent = async (
     start_time: activity.start_time.toISOString(),
   }
   if (activity.title !== undefined) structured.title = activity.title
+  if (post.message != null) structured.message = post.message
   if (activity.end_time) {
     structured.end_time = activity.end_time.toISOString()
     structured.duration_seconds = Math.round(

--- a/apps/backend/src/services/feed.integration.test.ts
+++ b/apps/backend/src/services/feed.integration.test.ts
@@ -127,9 +127,26 @@ describe('feed service', () => {
       expect(dto.activity_end_time).toBe(MERGED_END.toISOString())
       // Rendered `content` HTML (as federated) with the title headline (#884 §1).
       expect(dto.content).toContain('<strong>Merged run</strong>')
+      // The activity-date line is part of the federated content (#998).
+      expect(dto.content).toMatch(/<p>\w{3}, \d+ \w{3} \d{4}/)
+      // Typed resolved scalars back the web's native stat grid (#997).
+      expect(dto.metrics).toEqual([expect.objectContaining({ key: 'duration', value: expect.any(Number) })])
       // Base fields still present.
       expect(dto.included_metrics).toEqual(['duration'])
       expect(dto.visibility).toBe('public')
+    })
+
+    test('carries the personal message into the DTO and the federated content (#995)', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user)
+      const post = await createFeedPost(user, {
+        ...postInput(anchorId),
+        message: 'So wonderful\nsense of freedom!',
+      })
+
+      const dto = await serializeFeedPost(user, post)
+      expect(dto.message).toBe('So wonderful\nsense of freedom!')
+      expect(dto.content).toContain('<p>So wonderful<br>sense of freedom!</p>')
     })
 
     test('omits activity fields for a non-activity post', async () => {

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -23,8 +23,9 @@ import type { Activity, FeedPostRecord } from '../db/index.ts'
 
 import { getActivityById } from '../db/index.ts'
 import { resolveActivityScalars } from './activitypub/feed-activity.ts'
-import { feedPostContent } from './activitypub/object.ts'
+import { feedPostContent, formatActivityWindow } from './activitypub/object.ts'
 import { resolveActivityWindow } from './queries/index.ts'
+import { getSettings } from './settings.ts'
 
 /**
  * A feed post's shared activity, resolved for presentation/delivery: the title
@@ -36,6 +37,18 @@ export interface ResolvedFeedActivity {
   start_time: Date
   end_time?: Date
   title?: string
+}
+
+/**
+ * Normalize a request's `message` for storage: `undefined` stays `undefined`
+ * (a PATCH leaves the stored value unchanged), a whitespace-only string becomes
+ * `null` (clears it), anything else is stored trimmed. Shared by the REST
+ * router and the MCP tools so both surfaces behave identically.
+ */
+export const normalizeFeedMessage = (message?: string): string | null | undefined => {
+  if (message === undefined) return undefined
+  const trimmed = message.trim()
+  return trimmed === '' ? null : trimmed
 }
 
 /**
@@ -85,13 +98,29 @@ export const resolveFeedActivity = async (
 export const serializeFeedPost = async (user: string, record: FeedPostRecord): Promise<FeedPost> => {
   const activity = record.activity_id ? await resolveFeedActivity(user, record.activity_id) : null
   let content: string | undefined
+  let metrics: FeedPost['metrics']
   if (activity) {
     const scalars = await resolveActivityScalars(
       user,
       { end_time: activity.end_time, start_time: activity.start_time },
       record.included_metrics,
     )
-    content = feedPostContent(activity.title, activity.activity_type, scalars).content
+    const settings = await getSettings(user).catch(() => null)
+    content = feedPostContent(activity.title, activity.activity_type, scalars, {
+      message: record.message ?? undefined,
+      windowLabel: formatActivityWindow(
+        activity.start_time,
+        activity.end_time,
+        settings?.device_timezone ?? undefined,
+      ),
+    }).content
+    // The typed scalar values (same shape as the structured-enrichment payload),
+    // so the web renders a native stat grid instead of parsing the content HTML.
+    metrics = scalars.map(({ key, unit, value }) => ({
+      key,
+      value,
+      ...(unit === undefined ? {} : { unit }),
+    }))
   }
   return {
     activity_end_time: activity?.end_time?.toISOString(),
@@ -109,6 +138,8 @@ export const serializeFeedPost = async (user: string, record: FeedPostRecord): P
     include_map: record.include_map,
     included_metrics: record.included_metrics,
     kind: record.kind,
+    message: record.message ?? undefined,
+    metrics,
     series_metrics: record.series_metrics,
     updated_at: record.updated_at.toISOString(),
     visibility: record.visibility,

--- a/apps/web/src/components/ShareActivityDialog.css
+++ b/apps/web/src/components/ShareActivityDialog.css
@@ -109,9 +109,25 @@
   margin-top: 1rem;
 }
 
+.share-dialog-message {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font: inherit;
+  background: inherit;
+  color: inherit;
+}
+
 @media (prefers-color-scheme: dark) {
   .share-dialog {
     background: #1f2937;
+  }
+
+  .share-dialog-message {
+    border-color: #374151;
   }
 
   .share-dialog-header h2,

--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -33,6 +33,11 @@ interface Props {
   activityEnd?: Date
   /** Metrics currently shown on the activity's chart; mirrored into the defaults. */
   chartMetrics?: string[]
+  /**
+   * Prefill for the personal message (create mode) — typically the activity's
+   * description/comments, shown editable so the user can redact before sharing.
+   */
+  defaultMessage?: string
   /** When present, edit this existing post instead of sharing anew. */
   post?: FeedPost
   onClose: () => void
@@ -108,6 +113,7 @@ export function ShareActivityDialog({
   activityStart,
   activityEnd,
   chartMetrics,
+  defaultMessage,
   post,
   onClose,
   onShared,
@@ -128,6 +134,10 @@ export function ShareActivityDialog({
   )
   const [visibility, setVisibility] = useState<FeedVisibility>(post?.visibility ?? 'public')
   const [includeMap, setIncludeMap] = useState(post?.include_map ?? false)
+  // Edit mode shows the post's stored message; create mode prefills from the
+  // activity's description/comments (visible + editable — never auto-shared
+  // unseen). Emptying the field shares/keeps no text.
+  const [message, setMessage] = useState(post ? (post.message ?? '') : (defaultMessage ?? ''))
   const { summaryOptions, seriesOptions, canChart, canMap } = useShareableMetricOptions(
     activityStart,
     activityEnd,
@@ -149,6 +159,7 @@ export function ShareActivityDialog({
         canChart,
         canMap,
         includeMap,
+        message,
         series,
         seriesOptions,
         summary,
@@ -178,6 +189,22 @@ export function ShareActivityDialog({
           {post ? 'Editing' : 'Publish'} <strong>{activityTitle || 'this activity'}</strong>
           {post ? ' — followers get an update.' : ' to your federated feed.'}
         </p>
+
+        <fieldset class="share-dialog-group">
+          <legend>Message</legend>
+          <p class="share-dialog-note">
+            {!post && defaultMessage
+              ? 'Prefilled from the activity’s description — edit freely; empty shares no text.'
+              : 'Optional text shown at the top of the post.'}
+          </p>
+          <textarea
+            class="share-dialog-message"
+            rows={3}
+            value={message}
+            onInput={(e) => setMessage((e.target as HTMLTextAreaElement).value)}
+            placeholder="Say something about this activity…"
+          />
+        </fieldset>
 
         <fieldset class="share-dialog-group">
           <legend>Summary metrics</legend>

--- a/apps/web/src/components/feed-metrics.test.ts
+++ b/apps/web/src/components/feed-metrics.test.ts
@@ -70,12 +70,19 @@ describe('buildShareBody', () => {
     canChart: true,
     canMap: true,
     includeMap: false,
+    message: '',
     series: new Set<MetricType>(),
     seriesOptions: [{ key: 'heart_rate' }, { key: 'speed' }],
     summary: new Set<string>(),
     summaryOptions: [{ key: 'duration' }, { key: 'heart_rate_avg' }],
     visibility: 'public',
   }
+
+  it('passes the personal message through verbatim (backend normalizes blanks)', () => {
+    expect(buildShareBody({ ...base, message: 'Great run!' })).toMatchObject({ message: 'Great run!' })
+    // Always present — an emptied field must clear a stored message on edit.
+    expect(buildShareBody(base)).toMatchObject({ message: '' })
+  })
 
   it('attaches the chart image exactly when the heart-rate series is shared', () => {
     expect(buildShareBody({ ...base, series: new Set<MetricType>(['heart_rate']) })).toMatchObject({

--- a/apps/web/src/components/feed-metrics.ts
+++ b/apps/web/src/components/feed-metrics.ts
@@ -80,6 +80,8 @@ export interface ShareSelection {
   series: Set<MetricType>
   includeMap: boolean
   visibility: FeedVisibility
+  /** Personal message (plain text); whitespace-only clears/omits it server-side. */
+  message: string
   summaryOptions: readonly { key: string }[]
   seriesOptions: readonly { key: MetricType }[]
   canChart: boolean
@@ -96,6 +98,9 @@ export const buildShareBody = (sel: ShareSelection): ShareActivityBody => ({
   include_chart: sel.canChart && sel.series.has(HEART_RATE),
   include_map: sel.canMap && sel.includeMap,
   included_metrics: sel.summaryOptions.map((m) => m.key).filter((k) => sel.summary.has(k)),
+  // Always sent (never omitted): on an edit, an emptied field must CLEAR the
+  // stored message — the backend maps whitespace-only to null.
+  message: sel.message,
   series_metrics: sel.seriesOptions.map((m) => m.key).filter((k) => sel.series.has(k)),
   visibility: sel.visibility,
 })

--- a/apps/web/src/pages/EntityDetail/ShareActivityButton.tsx
+++ b/apps/web/src/pages/EntityDetail/ShareActivityButton.tsx
@@ -14,12 +14,15 @@ export const ShareActivityButton = ({
   activityStart,
   activityEnd,
   chartMetrics,
+  defaultMessage,
 }: {
   activityId: string
   activityTitle?: string
   activityStart?: Date
   activityEnd?: Date
   chartMetrics?: string[]
+  /** Prefill for the share message (the activity's description/comments). */
+  defaultMessage?: string
 }) => {
   const [open, setOpen] = useState(false)
   return (
@@ -44,6 +47,7 @@ export const ShareActivityButton = ({
           activityStart={activityStart}
           activityEnd={activityEnd}
           chartMetrics={chartMetrics}
+          defaultMessage={defaultMessage}
           onClose={() => setOpen(false)}
         />
       )}

--- a/apps/web/src/pages/EntityDetail/index.tsx
+++ b/apps/web/src/pages/EntityDetail/index.tsx
@@ -648,6 +648,10 @@ const ActivityContent = ({ entityId }: { entityId: string }) => {
           activityStart={activity.merged_start_time ?? activity.start_time}
           activityEnd={activity.merged_end_time ?? activity.end_time}
           chartMetrics={chartMetrics}
+          // Prefill the share message from the activity's description — the
+          // user-typed comments (the same text the edit Description field
+          // shows). Shown editable in the dialog, never auto-shared unseen (#995).
+          defaultMessage={getUserNotesContent(activity) || undefined}
         />
       )}
       {isMerging && <MergePanel activityId={rawEntityId} onCancel={() => setIsMerging(false)} />}

--- a/apps/web/src/pages/Feed/ActivityStatGrid.css
+++ b/apps/web/src/pages/Feed/ActivityStatGrid.css
@@ -1,0 +1,46 @@
+.activity-stat-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.activity-stat-cells {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.5rem;
+}
+
+.activity-stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.activity-stat-value {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.activity-stat-label {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.activity-stat-zones {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.activity-stat-zone strong {
+  font-weight: 600;
+}
+
+@media (prefers-color-scheme: dark) {
+  .activity-stat-label {
+    color: #9ca3af;
+  }
+}

--- a/apps/web/src/pages/Feed/ActivityStatGrid.tsx
+++ b/apps/web/src/pages/Feed/ActivityStatGrid.tsx
@@ -1,0 +1,40 @@
+/**
+ * Native Strava-style stat display for a shared activity (#997): each shared
+ * scalar as a big-value/small-label cell, with HR-zone minutes as their own
+ * compact row. Renders from the typed metrics (`FeedPost.metrics` on the
+ * owner's own card / public profile, `FeedStructuredActivity.metrics` on a peer
+ * timeline) — presentation only, no data fetch.
+ */
+import type { FeedStructuredMetric } from '@aurboda/api-spec'
+
+import { splitStats } from './activity-stats'
+import './ActivityStatGrid.css'
+
+export function ActivityStatGrid({ metrics }: { metrics: readonly FeedStructuredMetric[] }) {
+  const { cells, zones } = splitStats(metrics)
+  if (cells.length === 0 && zones.length === 0) return null
+  return (
+    <div class="activity-stat-grid">
+      {cells.length > 0 && (
+        <div class="activity-stat-cells">
+          {cells.map((cell) => (
+            <div key={cell.key} class="activity-stat">
+              <span class="activity-stat-value">{cell.value}</span>
+              <span class="activity-stat-label">{cell.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {zones.length > 0 && (
+        <div class="activity-stat-zones">
+          <span class="activity-stat-label">HR zones</span>
+          {zones.map((zone) => (
+            <span key={zone.zone} class="activity-stat-zone">
+              <strong>{zone.zone}</strong> {zone.minutes}m
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Feed/FeedPostCard.css
+++ b/apps/web/src/pages/Feed/FeedPostCard.css
@@ -68,6 +68,23 @@
   margin-bottom: 0;
 }
 
+/* The author's personal message — plain text with its linebreaks kept. */
+.feed-post-message {
+  white-space: pre-line;
+}
+
+/* The activity's own date/window (#998) — quieter than the message/stats. */
+.feed-post-window {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+@media (prefers-color-scheme: dark) {
+  .feed-post-window {
+    color: #9ca3af;
+  }
+}
+
 .feed-post-media {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/pages/Feed/FeedPostCard.tsx
+++ b/apps/web/src/pages/Feed/FeedPostCard.tsx
@@ -13,6 +13,8 @@ import type { ComponentChildren } from 'preact'
 import { formatDistanceToNow } from 'date-fns'
 
 import { API_URL } from '../../config'
+import { formatEntryWindow } from './activity-stats'
+import { ActivityStatGrid } from './ActivityStatGrid'
 import { ArticleContent } from './ArticleContent'
 import './FeedPostCard.css'
 
@@ -40,6 +42,24 @@ const imageUrl = (username: string, post: FeedPost, kind: 'chart' | 'route'): st
   post.visibility === 'followers'
     ? null
     : `${API_URL}/public/${encodeURIComponent(username)}/feed/${post.id}/${kind}.png`
+
+/**
+ * Native body for an activity post with resolved typed metrics (#997): title,
+ * personal message, the activity's own date (#998), and a stat grid — instead
+ * of the flattened `content` HTML Mastodon sees.
+ */
+const ActivityPostBody = ({ post }: { post: FeedPost }) => (
+  <div class="feed-post-content">
+    <p class="feed-post-title">
+      <strong>{post.activity_title ?? 'Shared activity'}</strong>
+    </p>
+    {post.message && <p class="feed-post-message">{post.message}</p>}
+    {post.activity_start_time && (
+      <p class="feed-post-window">{formatEntryWindow(post.activity_start_time, post.activity_end_time)}</p>
+    )}
+    {post.metrics && <ActivityStatGrid metrics={post.metrics} />}
+  </div>
+)
 
 export const FeedPostCard = ({
   post,
@@ -71,11 +91,14 @@ export const FeedPostCard = ({
       </header>
 
       {/* An article renders its own title + prose/chart blocks (prose sanitised
-          via the shared sanitiser). Otherwise the activity post's server-built,
-          HTML-escaped `content` (see serializeFeedPost) is safe to render
-          directly; remote timeline content will need sanitising. */}
+          via the shared sanitiser). An activity post with resolved typed metrics
+          renders natively (`ActivityPostBody`). Older payloads without `metrics`
+          fall back to the server-built, HTML-escaped `content` (safe to render
+          directly). */}
       {post.kind === 'article' && post.article ? (
         <ArticleContent article={post.article} />
+      ) : post.metrics ? (
+        <ActivityPostBody post={post} />
       ) : post.content ? (
         <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: post.content }} />
       ) : (

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -74,19 +74,26 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
       </header>
 
       {/* Sanitised server-side on ingest (timeline-ingest.ts) — safe to render.
-          Suppressed for a native article render (below), whose `content` is the
-          same title + prose + captions — else the article shows twice. */}
-      {entry.structured?.kind !== 'article' && (
+          Suppressed whenever the post has a native structured render (below),
+          whose content covers the same title/message/stats (article: title +
+          prose + captions; activity: title + message + date + stat grid) — else
+          the post shows twice (#997). */}
+      {!entry.structured && (
         <div class="feed-post-content" dangerouslySetInnerHTML={{ __html: entry.content }} />
       )}
 
       {/* Native structured data (Aurboda peers) → a real chart / inline article;
           otherwise fall back to the delivered image attachment(s), the way
-          Mastodon shows them. */}
-      {entry.structured ? (
-        <TimelineStructured structured={entry.structured} />
-      ) : (
-        entry.images?.map((img) => (
+          Mastodon shows them. An enriched *activity* post still shows its
+          delivered route map — the structured payload has no native map render —
+          but skips the chart PNG the native interactive chart duplicates (the
+          attachment names are Aurboda's own, so matching on them is stable). */}
+      {entry.structured && <TimelineStructured structured={entry.structured} />}
+      {entry.images
+        ?.filter((img) =>
+          entry.structured == null ? true : entry.structured.kind === 'activity' && img.name !== 'Heart rate',
+        )
+        .map((img) => (
           <img
             key={img.url}
             class="feed-post-image"
@@ -96,8 +103,7 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
             height={img.height}
             loading="lazy"
           />
-        ))
-      )}
+        ))}
     </article>
   )
 }

--- a/apps/web/src/pages/Feed/TimelineStructured.tsx
+++ b/apps/web/src/pages/Feed/TimelineStructured.tsx
@@ -1,14 +1,17 @@
 /**
  * Native rendering of a timeline post's Aurboda structured data. An `activity`
- * post renders an interactive line chart per shared high-resolution series
- * (hover shows real values) instead of a static image or plain text; an
- * `article` post renders the full inline article (title + resolved blocks —
- * see `TimelineArticle`). Only rendered for posts from Aurboda instances
- * (which carry `structured`); Mastodon posts have none.
+ * post renders natively (#997): title, the author's personal message, the
+ * activity's own date (#998), a Strava-style stat grid from the typed scalars,
+ * and an interactive line chart per shared high-resolution series (hover shows
+ * real values). An `article` post renders the full inline article (title +
+ * resolved blocks — see `TimelineArticle`). Only rendered for posts from
+ * Aurboda instances (which carry `structured`); Mastodon posts have none.
  */
 import type { FeedStructuredPost } from '@aurboda/api-spec'
 
 import { TrendLineChart } from '../../components/charts/TrendLineChart'
+import { formatEntryWindow } from './activity-stats'
+import { ActivityStatGrid } from './ActivityStatGrid'
 import { structuredChartSeries } from './timeline-structured'
 import { TimelineArticle } from './TimelineArticle'
 import './TimelineStructured.css'
@@ -17,9 +20,14 @@ export function TimelineStructured({ structured }: { structured: FeedStructuredP
   if (structured.kind === 'article') return <TimelineArticle article={structured} />
 
   const series = structuredChartSeries(structured)
-  if (series.length === 0) return null
   return (
     <div class="timeline-structured">
+      <p class="feed-post-title">
+        <strong>{structured.title ?? 'Shared activity'}</strong>
+      </p>
+      {structured.message && <p class="feed-post-message">{structured.message}</p>}
+      <p class="feed-post-window">{formatEntryWindow(structured.start_time, structured.end_time)}</p>
+      <ActivityStatGrid metrics={structured.metrics} />
       {series.map((s) => (
         <figure key={s.metric} class="timeline-chart">
           <figcaption class="timeline-chart-label">{s.label}</figcaption>

--- a/apps/web/src/pages/Feed/activity-stats.test.ts
+++ b/apps/web/src/pages/Feed/activity-stats.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest'
+
+import { formatEntryWindow, splitStats } from './activity-stats'
+
+describe('splitStats', () => {
+  test('maps scalars to labelled cells, humanizing seconds and appending units', () => {
+    const { cells, zones } = splitStats([
+      { key: 'duration', unit: 'seconds', value: 8895 },
+      { key: 'heart_rate_avg', unit: 'bpm', value: 107 },
+      { key: 'distance', unit: 'km', value: 8.235 },
+    ])
+    expect(cells).toEqual([
+      { key: 'duration', label: 'Duration', value: '2h 28m 15s' },
+      { key: 'heart_rate_avg', label: 'Avg HR', value: '107 bpm' },
+      { key: 'distance', label: 'Distance', value: '8.24 km' },
+    ])
+    expect(zones).toEqual([])
+  })
+
+  test('splits an HR-zone record into the compact zones row', () => {
+    const { cells, zones } = splitStats([{ key: 'hr_zone_minutes', value: { z0: 13, z1: 71, z2: 61 } }])
+    expect(cells).toEqual([])
+    expect(zones).toEqual([
+      { minutes: 13, zone: 'Rest' },
+      { minutes: 71, zone: 'Z1' },
+      { minutes: 61, zone: 'Z2' },
+    ])
+  })
+
+  test('falls back to the raw key as label for an unknown metric', () => {
+    const { cells } = splitStats([{ key: 'mystery_metric', value: 5 }])
+    expect(cells[0]?.label).toBe('mystery_metric')
+    expect(cells[0]?.value).toBe('5')
+  })
+})
+
+describe('formatEntryWindow', () => {
+  // Node's default test timezone is the machine's; pin behaviour by comparing
+  // structure rather than exact wall-clock times where the timezone matters.
+  test('same-day window collapses the end to its time', () => {
+    const label = formatEntryWindow('2026-08-02T10:00:00Z', '2026-08-02T11:30:00Z')
+    // One date, an en-dash, and a bare end time (no second date).
+    expect(label).toMatch(/^\w{3}, \d+ \w{3} \d{4}, \d{2}:\d{2}–\d{2}:\d{2}$/)
+  })
+
+  test('cross-day window spells out both ends', () => {
+    const label = formatEntryWindow('2026-08-02T01:00:00Z', '2026-08-05T23:00:00Z')
+    expect(label).toMatch(/^\w{3}, \d+ \w{3} \d{4}, \d{2}:\d{2} – \w{3}, \d+ \w{3} \d{4}, \d{2}:\d{2}$/)
+  })
+
+  test('open-ended window renders only the start', () => {
+    const label = formatEntryWindow('2026-08-02T10:00:00Z')
+    expect(label).toMatch(/^\w{3}, \d+ \w{3} \d{4}, \d{2}:\d{2}$/)
+  })
+})

--- a/apps/web/src/pages/Feed/activity-stats.ts
+++ b/apps/web/src/pages/Feed/activity-stats.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure helpers behind the native activity stat grid (#997): turn a post's typed
+ * scalar metrics (`FeedStructuredMetric[]` — the same shape the structured
+ * enrichment payload and the owner-facing `FeedPost.metrics` carry) into
+ * display-ready cells, plus the browser-local activity-date line (#998).
+ */
+import type { FeedStructuredMetric } from '@aurboda/api-spec'
+
+import { summaryLabel } from '../../components/feed-metrics'
+
+/** One big-value/small-label cell of the stat grid. */
+export interface StatCell {
+  key: string
+  label: string
+  value: string
+}
+
+/** One HR-zone entry of the compact zones row. */
+export interface ZoneStat {
+  zone: string
+  minutes: number
+}
+
+/** Render a seconds count as a compact human duration: 642 → `10m 42s`, 3720 → `1h 2m`. */
+const formatDuration = (totalSeconds: number): string => {
+  const s = Math.max(0, Math.round(totalSeconds))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  const parts: string[] = []
+  if (h) parts.push(`${h}h`)
+  if (m) parts.push(`${m}m`)
+  if (sec || parts.length === 0) parts.push(`${sec}s`)
+  return parts.join(' ')
+}
+
+/** Trim a numeric value for display: at most 2 decimals, no trailing zeros. */
+const formatNumber = (value: number): string => {
+  const rounded = Math.round(value * 100) / 100
+  return String(rounded)
+}
+
+/** `z0` → `Rest`, `z3` → `Z3` — the compact zone naming of the detail view. */
+const zoneName = (key: string): string => (key === 'z0' ? 'Rest' : key.toUpperCase())
+
+/**
+ * Split the typed metrics into stat-grid cells and the HR-zones row. A record
+ * value (HR-zone minutes) becomes the zones row; a scalar becomes a cell with a
+ * humanized duration for `seconds` units and the unit appended otherwise.
+ */
+export const splitStats = (
+  metrics: readonly FeedStructuredMetric[],
+): { cells: StatCell[]; zones: ZoneStat[] } => {
+  const cells: StatCell[] = []
+  const zones: ZoneStat[] = []
+  for (const metric of metrics) {
+    if (typeof metric.value === 'number') {
+      const value =
+        metric.unit === 'seconds'
+          ? formatDuration(metric.value)
+          : `${formatNumber(metric.value)}${metric.unit ? ` ${metric.unit}` : ''}`
+      cells.push({ key: metric.key, label: summaryLabel(metric.key), value })
+      continue
+    }
+    // The only record-valued scalar today is hr_zone_minutes; render any future
+    // record the same way (key/value pairs) rather than dropping it.
+    for (const [zone, minutes] of Object.entries(metric.value)) {
+      zones.push({ minutes, zone: zoneName(zone) })
+    }
+  }
+  return { cells, zones }
+}
+
+/**
+ * Browser-local activity-date line: `Sun, 2 Aug 2026, 15:44–18:12` for a
+ * same-day window, both ends spelled out across days, start only when open-ended.
+ * The viewer-local counterpart of the backend's `formatActivityWindow` (which
+ * renders the federated text in the author's timezone).
+ */
+export const formatEntryWindow = (startIso: string, endIso?: string): string => {
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    day: 'numeric',
+    month: 'short',
+    weekday: 'short',
+    year: 'numeric',
+  }
+  const timeOptions: Intl.DateTimeFormatOptions = { hour: '2-digit', hour12: false, minute: '2-digit' }
+  const full = (d: Date) =>
+    `${new Intl.DateTimeFormat('en-GB', dateOptions).format(d)}, ${new Intl.DateTimeFormat('en-GB', timeOptions).format(d)}`
+
+  const start = new Date(startIso)
+  if (endIso === undefined) return full(start)
+  const end = new Date(endIso)
+  const sameDay =
+    new Intl.DateTimeFormat('en-GB', dateOptions).format(start) ===
+    new Intl.DateTimeFormat('en-GB', dateOptions).format(end)
+  if (!sameDay) return `${full(start)} – ${full(end)}`
+  return `${full(start)}–${new Intl.DateTimeFormat('en-GB', timeOptions).format(end)}`
+}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -77,6 +77,11 @@ explicit metric selection that bounds what is shared:
   with the `followers` audience.
 - **`include_chart` / `include_map`** — attach a rendered heart-rate chart and/or
   GPS route-map image to the post (see [Images](#images)).
+- **`message`** — an optional personal message (plain text, linebreaks preserved)
+  shown at the top of the post. The share dialog prefills it from the activity's
+  description (its user-typed comments) — always shown editable before sharing, so
+  private context can be redacted; an empty field shares no text. Cleared on edit
+  by saving an emptied field.
 
 Defaults are privacy-conservative: sharing an activity with no explicit selection
 shares no scalars and, crucially, **no series**.
@@ -123,8 +128,11 @@ is a later slice):
 | Edit    | `Update{Note}`      | Their stored copy is replaced             |
 | Unshare | `Delete{Tombstone}` | The post is retracted from their timeline |
 
-The `Note` is Mastodon-compatible: an HTML `content` summary flattening the title and the
-shared scalar summaries, plus a `name` headline, addressed per the post's visibility
+The `Note` is Mastodon-compatible: a structured HTML `content` — the bold title
+headline, the author's personal message (if any), a line saying when the **activity**
+happened (rendered in the author's device timezone, since AS2 `published` stays the
+share time for timeline ordering), and the shared scalar summaries one per line —
+plus a `name` headline, addressed per the post's visibility
 (`public` → AS2 Public + followers; `unlisted` → followers + Public in `cc`; `followers`
 → followers only). The custom structured `aurboda:` extension (typed metrics + series
 links) is a separate, richer representation for Aurboda-to-Aurboda consumers.
@@ -229,11 +237,16 @@ When a `Create` or `Update` for a `Note` is delivered, the inbox:
 4. upserts a `timeline_entry` (keyed by the note's `object_uri`, so an `Update` or a
    redelivery replaces in place rather than duplicating).
 
-Each card renders the sanitised HTML plus, below it, the **native structured chart** when the
-post carried one (Aurboda peers, see below) — otherwise the delivered **image attachment(s)**,
-the way Mastodon shows them. A `followers`-only Aurboda share federates its native chart to
-accepted followers too (via the capability token, see below), so a follower gets the
-interactive chart rather than just the flat image; a Mastodon photo post shows its photos.
+A card with **no** native structured payload (a Mastodon post) renders the sanitised HTML
+plus the delivered **image attachment(s)**, the way Mastodon shows them. A card **with** one
+(an Aurboda peer's post, see below) renders natively instead and suppresses the redundant
+flattened HTML: an activity share shows its title, the author's message, the activity's
+date, a stat grid, and an interactive chart per shared series — plus the delivered route-map
+image (which has no native render; the chart PNG the native chart duplicates is skipped) —
+while an article shows the full inline article. A `followers`-only Aurboda share federates
+its native payload to accepted followers too (via the capability token, see below), so a
+follower gets the interactive chart rather than just the flat image; a Mastodon photo post
+shows its photos.
 
 A `Delete` removes the matching entry; unfollowing removes all of that actor's entries. The
 timeline is read back **newest-first**, keyset-paginated on `(published_at, id)` behind an
@@ -296,8 +309,10 @@ structured data out-of-band on ingest:
    shows with its HTML.
 3. **Store + render.** The payload is stored on `timeline_entry.structured` (JSONB, NULL for
    non-Aurboda posts; a redelivery that can't re-fetch keeps the last-known value). The web
-   timeline card renders, per `structured.kind`: a native `TrendLineChart` per shared series for
-   an **activity** post, or the full inline article — title, prose, per-block chart/scatter — for
+   timeline card renders, per `structured.kind`: for an **activity** post the native
+   activity card — title, personal message, the activity's date, a Strava-style **stat
+   grid** from the typed scalars, and a native `TrendLineChart` per shared series — or the
+   full inline article — title, prose, per-block chart/scatter — for
    an **article** post (mirroring the author's own live `ArticleContent` render, but built from
    the embedded payload rather than a live fetch, since a receiving peer has no credentials to
    call the author's authenticated endpoints).
@@ -441,7 +456,11 @@ resolving.
 ## Using it in the web app
 
 - **Share** — an activity's detail page has a **Share to feed** button. It opens a dialog
-  to pick the summary metrics, optionally opt into full series, and choose the audience.
+  to write an optional personal message (prefilled from the activity's description /
+  comments, fully editable), pick the summary metrics, optionally opt into full series,
+  and choose the audience. The user's own feed cards and public profile render the shared
+  scalars as a native **stat grid** (with the message and the activity's date) rather than
+  the flattened text Mastodon sees.
 - **New article** — the **Feed** page has a **New article** button that opens the article
   composer: a title, an optional default time window, and an ordered list of **prose**
   (markdown), **chart** (a metric + optional per-block window + caption), and **correlation**
@@ -531,7 +550,8 @@ toggled with the `manually_approve_followers` user setting (`get_user_settings` 
 Feed posts live in the user's own database in the `feed_posts` table. A `kind` column
 discriminates an `activity` post from an `article` post; an article's content (title +
 default window + ordered blocks) lives in a nullable `article` JSONB column, and its
-`activity_id`/metric columns stay empty. `activity_id` is a
+`activity_id`/metric columns stay empty. A nullable `message` column holds the author's
+personal message (plain text; NULL when none was shared). `activity_id` is a
 **soft reference** (no foreign key): activities are soft-deleted and the series lookup
 re-checks `deleted_at` at query time, so a removed activity simply stops resolving rather
 than cascading a delete. A GIN index over `series_metrics` backs the public series

--- a/packages/api-spec/src/schemas/feed-structured.ts
+++ b/packages/api-spec/src/schemas/feed-structured.ts
@@ -81,6 +81,10 @@ export const feedStructuredSchema = z
       .optional()
       .meta({ description: 'Activity duration in seconds (present when the activity has an end)' }),
     end_time: iso8601DateTimeSchema.optional().meta({ description: 'Activity end (ISO 8601), if any' }),
+    message: z
+      .string()
+      .optional()
+      .meta({ description: "The author's personal message for the post (plain text), if any" }),
     metrics: z.array(feedStructuredMetricSchema).meta({ description: 'Shared scalar summaries' }),
     series: z
       .array(feedStructuredSeriesSchema)

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -26,7 +26,11 @@ import { z } from 'zod'
 
 import { baseResponseSchema, iso8601DateTimeSchema, metricTypeSchema } from './common.ts'
 import { selectorSchema } from './correlations.ts'
-import { feedStructuredPostSchema, publicSeriesSampleSchema } from './feed-structured.ts'
+import {
+  feedStructuredMetricSchema,
+  feedStructuredPostSchema,
+  publicSeriesSampleSchema,
+} from './feed-structured.ts'
 import { shareVisibilityValues } from './visibility.ts'
 
 /**
@@ -70,6 +74,10 @@ export const shareActivityBodySchema = z
       .max(64)
       .default([])
       .meta({ description: 'Scalar-summary metric keys to share (the single source of truth for the post)' }),
+    message: z.string().max(2000).optional().meta({
+      description:
+        'Personal message shown above the shared stats (plain text; linebreaks preserved). Empty/absent shares no text.',
+    }),
     series_metrics: z.array(metricTypeSchema).max(64).default([]).meta({
       description:
         'Metrics whose full high-resolution series are explicitly shared. Separate opt-in from the scalar summary; empty by default.',
@@ -90,6 +98,9 @@ export const updateFeedPostBodySchema = z
       .max(64)
       .optional()
       .meta({ description: 'Replacement set of shared scalar-summary metric keys' }),
+    message: z.string().max(2000).optional().meta({
+      description: 'Replacement personal message; an empty string clears it. Omit to keep the current one.',
+    }),
     series_metrics: z
       .array(metricTypeSchema)
       .max(64)
@@ -272,6 +283,18 @@ export const feedPostSchema = z
     include_map: z.boolean().meta({ description: 'Whether a route-map image is attached' }),
     included_metrics: z.array(z.string()).meta({ description: 'Shared scalar-summary metric keys' }),
     kind: feedPostKindSchema.meta({ description: 'Post kind (`activity` or `article`)' }),
+    message: z
+      .string()
+      .optional()
+      .meta({ description: 'Personal message shared with the post (plain text), if any' }),
+    // The resolved scalar values behind `included_metrics`, typed — the same
+    // shapes the structured-enrichment payload carries — so the web can render a
+    // native stat grid instead of parsing the flattened `content` HTML. Resolved
+    // at query time like `content`; absent when there is no resolvable activity.
+    metrics: z
+      .array(feedStructuredMetricSchema)
+      .optional()
+      .meta({ description: 'Resolved typed scalar values for the shared metrics (activity posts)' }),
     series_metrics: z.array(z.string()).meta({ description: 'Explicitly-shared series metrics' }),
     updated_at: z.string().meta({ description: 'Last update timestamp (ISO 8601)' }),
     visibility: feedVisibilitySchema,
@@ -617,10 +640,9 @@ export type FeedPostStructuredResponse = z.infer<typeof feedPostStructuredRespon
  */
 export const articleExportResponseSchema = baseResponseSchema
   .extend({
-    markdown: z
-      .string()
-      .optional()
-      .meta({ description: 'Paste-ready markdown: title + prose + one image link per chart/correlation block' }),
+    markdown: z.string().optional().meta({
+      description: 'Paste-ready markdown: title + prose + one image link per chart/correlation block',
+    }),
   })
   .meta({ id: 'ArticleExportResponse' })
 


### PR DESCRIPTION
First slice of the sharing-polish round from the 2026-08-19 tryout feedback: improve what an activity share *says and shows* before tackling the enrichment gap (#996).

## #995 — personal message on activity shares
- New nullable `message` column on `feed_posts` (idempotent additive migration).
- `message` on `ShareActivityBody` / `UpdateFeedPostBody` / `FeedPost` / `FeedStructured` (api-spec), REST + MCP wired through a shared `normalizeFeedMessage` (blank ⇒ clear/NULL, omitted ⇒ unchanged on PATCH).
- Share dialog: **Message** textarea, prefilled in create mode from the activity's description — the user-typed comments backing the edit "Description" field — always shown editable so nothing private auto-shares unseen; empty shares no text.
- Delivery: the message renders into the Note's HTML content (escaped, linebreaks kept) and rides `aurboda:message` on the AS2 object + `message` on the structured-enrichment payload, so Mastodon, the own card, and Aurboda peers all see it.

## #997 — presentation
- Federated Note HTML is now structured paragraphs: **headline / message / activity-date line / one stat per line** (`<br>`-separated) instead of the `·`-joined run-on sentence. Mastodon keeps `<p>`/`<br>`, so it reads cleanly there.
- `FeedPost` gains typed `metrics` (the resolved scalars, same `FeedStructuredMetric` shape as enrichment), and the own-feed card, public profile, and peer home timeline render a native Strava-style **stat grid** (`ActivityStatGrid`, HR zones as a compact row).
- An enriched activity timeline card now suppresses the redundant flattened HTML (mirroring the #971 article treatment, same #973 caveat), keeps the delivered **route-map** image (no native map render exists), and skips the chart PNG that the native interactive chart duplicates.

## #998 — activity date visible (option B)
- AS2 `published` stays the share time (timeline-ordering semantics untouched); instead every surface shows when the **activity** happened: `formatActivityWindow` renders `Sun, 2 Aug 2026, 15:44–18:12` (same-day collapse, cross-day spelled out) in the author's device timezone for federated text, and the web cards render it viewer-local.

## Tests & docs
- Unit: content layout (message escaping/linebreaks/order, one-stat-per-line, `aurboda:message`), window formatting (same-day/cross-day/open-ended/invalid-tz), stat splitting + zone naming, share-body message passthrough.
- Integration: message round-trip + patch semantics (replace/clear/keep) on `feed_posts`, message in `serializeFeedPost` DTO + federated content, message on the structured payload.
- `docs/features/feed.md` updated; api-spec regenerated (OpenAPI/TS/Kotlin).

Closes #995. Closes #997. Closes #998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo