### PR TITLE
fix(feed): run the feed_posts.message migration (missing tableCreationOrder key)

### DIFF
--- a/apps/backend/src/schema.test.ts
+++ b/apps/backend/src/schema.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+
+import { createTableStatements, tableCreationOrder } from './schema.ts'
+
+/**
+ * The schema runner executes ONLY the keys listed in `tableCreationOrder` —
+ * a statement present in `createTableStatements` but missing from the order
+ * list silently never runs. For an additive column migration that is
+ * invisible locally (fresh DBs get the column from the CREATE TABLE) and
+ * breaks only in production on existing databases, as `feed_posts.message`
+ * did (#1000 → 500 on share). These two sets must therefore stay identical.
+ */
+describe('schema statement wiring', () => {
+  test('every createTableStatements key is listed in tableCreationOrder', () => {
+    const ordered = new Set(tableCreationOrder)
+    const missing = Object.keys(createTableStatements).filter((key) => !ordered.has(key))
+    expect(missing).toEqual([])
+  })
+
+  test('tableCreationOrder lists no unknown or duplicate keys', () => {
+    const unknown = tableCreationOrder.filter((key) => !(key in createTableStatements))
+    expect(unknown).toEqual([])
+    expect(new Set(tableCreationOrder).size).toBe(tableCreationOrder.length)
+  })
+})

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -143,6 +143,7 @@ export const tableCreationOrder = [
   'challenge_participations_indexes',
   'feed_posts',
   'feed_posts_article_columns',
+  'feed_posts_message_column',
   'feed_posts_indexes',
   'feed_tombstone',
   'feed_actor',

--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -285,7 +285,7 @@ export function ShareActivityDialog({
             disabled={mutation.isPending || !summaryOptions.some((m) => summary.has(m.key))}
             onClick={() => mutation.mutate()}
           >
-            {mutation.isPending ? 'Saving…' : post ? 'Save changes' : 'Share'}
+            {mutation.isPending ? (post ? 'Saving…' : 'Sharing…') : post ? 'Save changes' : 'Share'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
Fixes the production 500 on sharing an activity after #1000:

```
error: column "message" of relation "feed_posts" does not exist
```

**Root cause:** #1000 added the additive migration `feed_posts_message_column` to `socialTables`, but the schema runner executes only keys listed in `tableCreationOrder` (`schema.ts`) — the new key wasn't added there, so the `ALTER TABLE … ADD COLUMN IF NOT EXISTS message` never ran. Existing databases kept the old table; the auto-migration retry re-ran the same list and failed again. Every test passed because fresh test databases get the column from the updated `CREATE TABLE` statement instead.

**Fix**
- List `feed_posts_message_column` in `tableCreationOrder` (additive-column keys run unconditionally — their key never matches an existing table name).
- New `schema.test.ts`: asserts `createTableStatements` ↔ `tableCreationOrder` are identical sets (no orphaned statements, no unknown/duplicate keys). It confirms no *other* statement is currently orphaned, and makes this silent-no-op class impossible to reintroduce.
- Drive-by from the same report: the share dialog's pending button label now reads **"Sharing…"** in create mode (was "Saving…").

After deploy, the first request that hits the schema-error retry path will add the column and sharing works — no manual intervention needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo