### PR TITLE
feat(feed): own feed renders the peer-identical native card (#1008)

### DIFF
--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -80,7 +80,11 @@ export const createFeedRouter = (
   router.get<Record<string, never>, FeedPostsResponse>('/', authMiddleware, async (req, res) => {
     const user = req.user!
     const records = await listFeedPosts(user)
-    const posts = await Promise.all(records.map((record) => serializeFeedPost(user, record)))
+    // The owner's feed includes each activity post's full structured payload,
+    // so the web renders the same native card a subscribing peer sees (#1008).
+    const posts = await Promise.all(
+      records.map((record) => serializeFeedPost(user, record, { includeStructured: true })),
+    )
     res.json({ posts, success: true })
   })
 
@@ -165,7 +169,7 @@ export const createFeedRouter = (
       })
       // Fan the post out to followers (best-effort; never blocks the response).
       deliver?.created(user, record, activity)
-      res.json({ post: await serializeFeedPost(user, record), success: true })
+      res.json({ post: await serializeFeedPost(user, record, { includeStructured: true }), success: true })
     },
   )
 
@@ -279,7 +283,7 @@ export const createFeedRouter = (
       // activity, so it must go through the article path — `updated` would no-op.
       if (record.kind === 'article') deliver?.updatedArticle(user, record)
       else deliver?.updated(user, record)
-      res.json({ post: await serializeFeedPost(user, record), success: true })
+      res.json({ post: await serializeFeedPost(user, record, { includeStructured: true }), success: true })
     },
   )
 

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -80,8 +80,6 @@ export const createFeedRouter = (
   router.get<Record<string, never>, FeedPostsResponse>('/', authMiddleware, async (req, res) => {
     const user = req.user!
     const records = await listFeedPosts(user)
-    // The owner's feed includes each activity post's full structured payload,
-    // so the web renders the same native card a subscribing peer sees (#1008).
     const posts = await Promise.all(
       records.map((record) => serializeFeedPost(user, record, { includeStructured: true })),
     )

--- a/apps/backend/src/services/feed-structured-activity.ts
+++ b/apps/backend/src/services/feed-structured-activity.ts
@@ -1,0 +1,93 @@
+/**
+ * Assembly of an *activity* post's native structured payload
+ * (`FeedStructuredActivity`) from its resolved pieces.
+ *
+ * A leaf module (no import back into `feed.ts`/`feed-structured.ts`) shared by
+ * two producers so their payloads can never drift:
+ *
+ * - the public structured endpoint (`feed-structured.ts`) — what a subscribing
+ *   Aurboda peer fetches and renders in its home timeline, and
+ * - the owner-facing feed serialisation (`feed.ts`) — so the author's own feed
+ *   card renders the **identical** payload with the identical component
+ *   (#1008: "my own feed should look like it would for another Aurboda
+ *   subscriber").
+ */
+import { type FeedStructuredActivity, type FeedStructuredSeries, metricTypeSchema } from '@aurboda/api-spec'
+
+import type { ScalarMetric } from './activitypub/object.ts'
+
+import { resolvePublicSeries } from './feed-series.ts'
+import { queryMetricsBucketed } from './queries/index.ts'
+
+/** Series granularity for the structured payload — floored to the server minimum by `resolvePublicSeries`. */
+const SERIES_BUCKET = '5s'
+
+/**
+ * Resolve a post's opted-in series to inline samples over its activity window.
+ *
+ * The authorization boundary is the post itself: the caller has already
+ * checked the requester may see this post, and we only ever iterate the post's
+ * own `seriesMetrics` over its own `[start, end]`. So the covering window *is*
+ * that window — we don't route through the public-only
+ * `findCoveringSharedSeriesWindow` (which correctly rejects a `followers`-only
+ * share for the public `/series` endpoint, but would wrongly blank the chart
+ * here for a token-authorized follower or the owner).
+ */
+export const resolveStructuredSeries = async (
+  user: string,
+  seriesMetrics: string[],
+  start: Date,
+  end: Date,
+): Promise<FeedStructuredSeries[]> => {
+  const series: FeedStructuredSeries[] = []
+  for (const raw of seriesMetrics) {
+    const parsed = metricTypeSchema.safeParse(raw)
+    if (!parsed.success) continue
+    const result = await resolvePublicSeries(parsed.data, start, end, SERIES_BUCKET, {
+      findCoveringWindow: async () => ({ end_time: end, start_time: start }),
+      queryBucketed: (m, s, e, b) => queryMetricsBucketed(user, [m], s, e, b, {}),
+    })
+    if (result) {
+      series.push({
+        bucket: result.bucket,
+        metric: result.metric,
+        samples: result.samples,
+        unit: result.unit,
+      })
+    }
+  }
+  return series
+}
+
+/** The activity fields the payload needs (satisfied by `ResolvedFeedActivity`). */
+export interface StructuredActivitySource {
+  activity_type: string
+  start_time: Date
+  end_time?: Date
+  title?: string
+}
+
+/** Assemble the `FeedStructuredActivity` payload from its resolved pieces. */
+export const assembleStructuredActivity = (
+  activity: StructuredActivitySource,
+  scalars: ScalarMetric[],
+  series: FeedStructuredSeries[],
+  message?: string | null,
+): FeedStructuredActivity => {
+  const structured: FeedStructuredActivity = {
+    activity_type: activity.activity_type,
+    kind: 'activity',
+    metrics: scalars.map(({ key, unit, value }) => ({ key, value, ...(unit === undefined ? {} : { unit }) })),
+    series,
+    start_time: activity.start_time.toISOString(),
+  }
+  if (activity.title !== undefined) structured.title = activity.title
+  if (message != null) structured.message = message
+  if (activity.end_time) {
+    structured.end_time = activity.end_time.toISOString()
+    structured.duration_seconds = Math.round(
+      (activity.end_time.getTime() - activity.start_time.getTime()) / 1000,
+    )
+  }
+  return structured
+}

--- a/apps/backend/src/services/feed-structured.ts
+++ b/apps/backend/src/services/feed-structured.ts
@@ -19,16 +19,14 @@
 import type {
   ArticleBlock,
   ArticleContent,
-  FeedStructuredActivity,
   FeedStructuredArticle,
   FeedStructuredArticleBlock,
   FeedStructuredArticleChartBlock,
   FeedStructuredArticleCorrelationBlock,
   FeedStructuredPost,
-  FeedStructuredSeries,
 } from '@aurboda/api-spec'
 
-import { defaultArticleChartBucket, metricTypeSchema } from '@aurboda/api-spec'
+import { defaultArticleChartBucket } from '@aurboda/api-spec'
 
 import type { FeedPostRecord } from '../db/index.ts'
 
@@ -38,49 +36,12 @@ import { resolveActivityScalars } from './activitypub/feed-activity.ts'
 import { blockWindow, isZeroDurationBucket } from './article.ts'
 import { getContinuousCorrelation } from './correlations/explore.ts'
 import { isCapabilityAuthorized } from './feed-capability.ts'
-import { floorSeriesBucket, resolvePublicSeries, samplesFromBucketedResult } from './feed-series.ts'
+import { floorSeriesBucket, samplesFromBucketedResult } from './feed-series.ts'
+// Series + payload assembly live in the shared leaf module so the owner-facing
+// feed serialisation (`feed.ts`) produces the identical payload (#1008).
+import { assembleStructuredActivity, resolveStructuredSeries } from './feed-structured-activity.ts'
 import { resolveFeedActivity } from './feed.ts'
 import { queryMetricsBucketed } from './queries/index.ts'
-
-/** Series granularity for the structured payload — floored to the server minimum by `resolvePublicSeries`. */
-const SERIES_BUCKET = '5s'
-
-/**
- * Resolve a post's opted-in series to inline samples over its activity window.
- *
- * The authorization boundary is the post itself: `resolveStructuredPost` has
- * already checked the caller may see this post, and we only ever iterate the
- * post's own `seriesMetrics` over its own `[start, end]`. So the covering window
- * *is* that window — we don't route through the public-only
- * `findCoveringSharedSeriesWindow` (which correctly rejects a `followers`-only
- * share for the public `/series` endpoint, but would wrongly blank the chart
- * here for a token-authorized follower).
- */
-const resolveStructuredSeries = async (
-  user: string,
-  seriesMetrics: string[],
-  start: Date,
-  end: Date,
-): Promise<FeedStructuredSeries[]> => {
-  const series: FeedStructuredSeries[] = []
-  for (const raw of seriesMetrics) {
-    const parsed = metricTypeSchema.safeParse(raw)
-    if (!parsed.success) continue
-    const result = await resolvePublicSeries(parsed.data, start, end, SERIES_BUCKET, {
-      findCoveringWindow: async () => ({ end_time: end, start_time: start }),
-      queryBucketed: (m, s, e, b) => queryMetricsBucketed(user, [m], s, e, b, {}),
-    })
-    if (result) {
-      series.push({
-        bucket: result.bucket,
-        metric: result.metric,
-        samples: result.samples,
-        unit: result.unit,
-      })
-    }
-  }
-  return series
-}
 
 /**
  * Resolve one article `chart` block to its structured samples over its
@@ -262,22 +223,7 @@ export const resolveStructuredContent = async (
     ? await resolveStructuredSeries(user, post.series_metrics, activity.start_time, activity.end_time)
     : []
 
-  const structured: FeedStructuredActivity = {
-    activity_type: activity.activity_type,
-    kind: 'activity',
-    metrics: scalars.map(({ key, unit, value }) => ({ key, value, ...(unit === undefined ? {} : { unit }) })),
-    series,
-    start_time: activity.start_time.toISOString(),
-  }
-  if (activity.title !== undefined) structured.title = activity.title
-  if (post.message != null) structured.message = post.message
-  if (activity.end_time) {
-    structured.end_time = activity.end_time.toISOString()
-    structured.duration_seconds = Math.round(
-      (activity.end_time.getTime() - activity.start_time.getTime()) / 1000,
-    )
-  }
-  return structured
+  return assembleStructuredActivity(activity, scalars, series, post.message)
 }
 
 /**

--- a/apps/backend/src/services/feed.integration.test.ts
+++ b/apps/backend/src/services/feed.integration.test.ts
@@ -149,6 +149,27 @@ describe('feed service', () => {
       expect(dto.content).toContain('<p>So wonderful<br>sense of freedom!</p>')
     })
 
+    test('includeStructured attaches the peer-identical structured payload (#1008)', async () => {
+      const user = getTestUser()
+      const anchorId = await insertAnchor(user)
+      const post = await createFeedPost(user, { ...postInput(anchorId), message: 'Native!' })
+
+      // Default: no structured payload (public profile / MCP weight).
+      const plain = await serializeFeedPost(user, post)
+      expect(plain.structured).toBeUndefined()
+
+      const dto = await serializeFeedPost(user, post, { includeStructured: true })
+      expect(dto.structured?.kind).toBe('activity')
+      if (dto.structured?.kind !== 'activity') throw new Error('expected an activity payload')
+      expect(dto.structured.activity_type).toBe('exercise')
+      expect(dto.structured.message).toBe('Native!')
+      expect(dto.structured.start_time).toBe(ANCHOR_START.toISOString())
+      // Same typed scalars as the flat `metrics` field — one resolution feeds both.
+      expect(dto.structured.metrics).toEqual(dto.metrics)
+      // No series opted in → empty, never undefined.
+      expect(dto.structured.series).toEqual([])
+    })
+
     test('omits activity fields for a non-activity post', async () => {
       const user = getTestUser()
       const post = await createFeedPost(user, postInput(null))

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -85,18 +85,6 @@ export const resolveFeedActivity = async (
 }
 
 /**
- * Serialise a stored feed post for the owner-facing REST/MCP surface, enriching
- * it with the shared activity's title/type, the **merged-span** window, and the
- * exact `content` HTML the post federates with — all resolved at query time. A
- * client can therefore render the post WYSIWYG (as it appears on Mastodon) and
- * re-open the share dialog without a second per-post activity fetch.
- *
- * The `content` is the same server-built, HTML-escaped string the delivered Note
- * carries (via `feedPostContent`), so the web renders it directly. (When the feed
- * later renders *remote* actors' posts, that untrusted content will need
- * sanitising — this owner-facing content does not.)
- */
-/**
  * The presentation pieces derived from a post's resolved activity: the
  * federated `content` HTML, the typed scalar `metrics`, and (opt-in) the FULL
  * structured payload — assembled by the same helper the public structured
@@ -144,6 +132,18 @@ const resolveActivityPresentation = async (
   }
 }
 
+/**
+ * Serialise a stored feed post for the owner-facing REST/MCP surface, enriching
+ * it with the shared activity's title/type, the **merged-span** window, and the
+ * exact `content` HTML the post federates with — all resolved at query time. A
+ * client can therefore render the post WYSIWYG (as it appears on Mastodon) and
+ * re-open the share dialog without a second per-post activity fetch.
+ *
+ * The `content` is the same server-built, HTML-escaped string the delivered Note
+ * carries (via `feedPostContent`), so the web renders it directly. (When the feed
+ * later renders *remote* actors' posts, that untrusted content will need
+ * sanitising — this owner-facing content does not.)
+ */
 export const serializeFeedPost = async (
   user: string,
   record: FeedPostRecord,

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -24,6 +24,7 @@ import type { Activity, FeedPostRecord } from '../db/index.ts'
 import { getActivityById } from '../db/index.ts'
 import { resolveActivityScalars } from './activitypub/feed-activity.ts'
 import { feedPostContent, formatActivityWindow } from './activitypub/object.ts'
+import { assembleStructuredActivity, resolveStructuredSeries } from './feed-structured-activity.ts'
 import { resolveActivityWindow } from './queries/index.ts'
 import { getSettings } from './settings.ts'
 
@@ -95,33 +96,63 @@ export const resolveFeedActivity = async (
  * later renders *remote* actors' posts, that untrusted content will need
  * sanitising — this owner-facing content does not.)
  */
-export const serializeFeedPost = async (user: string, record: FeedPostRecord): Promise<FeedPost> => {
-  const activity = record.activity_id ? await resolveFeedActivity(user, record.activity_id) : null
-  let content: string | undefined
-  let metrics: FeedPost['metrics']
-  if (activity) {
-    const scalars = await resolveActivityScalars(
-      user,
-      { end_time: activity.end_time, start_time: activity.start_time },
-      record.included_metrics,
-    )
-    const settings = await getSettings(user).catch(() => null)
-    content = feedPostContent(activity.title, activity.activity_type, scalars, {
-      message: record.message ?? undefined,
-      windowLabel: formatActivityWindow(
-        activity.start_time,
-        activity.end_time,
-        settings?.device_timezone ?? undefined,
-      ),
-    }).content
+/**
+ * The presentation pieces derived from a post's resolved activity: the
+ * federated `content` HTML, the typed scalar `metrics`, and (opt-in) the FULL
+ * structured payload — assembled by the same helper the public structured
+ * endpoint uses, so the author's own card renders exactly what a subscribing
+ * Aurboda peer's timeline renders (#1008). `structured` is off by default:
+ * the public profile listing and MCP tools don't need the series weight.
+ */
+const resolveActivityPresentation = async (
+  user: string,
+  record: FeedPostRecord,
+  activity: ResolvedFeedActivity,
+  includeStructured: boolean,
+): Promise<Pick<FeedPost, 'content' | 'metrics' | 'structured'>> => {
+  const scalars = await resolveActivityScalars(
+    user,
+    { end_time: activity.end_time, start_time: activity.start_time },
+    record.included_metrics,
+  )
+  const settings = await getSettings(user).catch(() => null)
+  const content = feedPostContent(activity.title, activity.activity_type, scalars, {
+    message: record.message ?? undefined,
+    windowLabel: formatActivityWindow(
+      activity.start_time,
+      activity.end_time,
+      settings?.device_timezone ?? undefined,
+    ),
+  }).content
+  let structured: FeedPost['structured']
+  if (includeStructured && record.kind === 'activity') {
+    const series = activity.end_time
+      ? await resolveStructuredSeries(user, record.series_metrics, activity.start_time, activity.end_time)
+      : []
+    structured = assembleStructuredActivity(activity, scalars, series, record.message)
+  }
+  return {
+    content,
     // The typed scalar values (same shape as the structured-enrichment payload),
     // so the web renders a native stat grid instead of parsing the content HTML.
-    metrics = scalars.map(({ key, unit, value }) => ({
+    metrics: scalars.map(({ key, unit, value }) => ({
       key,
       value,
       ...(unit === undefined ? {} : { unit }),
-    }))
+    })),
+    structured,
   }
+}
+
+export const serializeFeedPost = async (
+  user: string,
+  record: FeedPostRecord,
+  opts: { includeStructured?: boolean } = {},
+): Promise<FeedPost> => {
+  const activity = record.activity_id ? await resolveFeedActivity(user, record.activity_id) : null
+  const { content, metrics, structured } = activity
+    ? await resolveActivityPresentation(user, record, activity, opts.includeStructured ?? false)
+    : { content: undefined, metrics: undefined, structured: undefined }
   return {
     activity_end_time: activity?.end_time?.toISOString(),
     activity_id: record.activity_id,
@@ -141,6 +172,7 @@ export const serializeFeedPost = async (user: string, record: FeedPostRecord): P
     message: record.message ?? undefined,
     metrics,
     series_metrics: record.series_metrics,
+    structured,
     updated_at: record.updated_at.toISOString(),
     visibility: record.visibility,
   }

--- a/apps/web/src/pages/Feed/FeedPostCard.tsx
+++ b/apps/web/src/pages/Feed/FeedPostCard.tsx
@@ -46,6 +46,22 @@ const imageUrl = (username: string, post: FeedPost, kind: 'chart' | 'route'): st
     : `${API_URL}/public/${encodeURIComponent(username)}/feed/${post.id}/${kind}.png`
 
 /**
+ * The post's static image URLs. The chart.png is replaced only when the native
+ * interactive chart ACTUALLY renders — `structured` is attached to every
+ * activity post, so keying on its mere presence would drop the chart from an
+ * `include_chart` post whose series is empty/undrawable. The route map has no
+ * native render, so its image always stays.
+ */
+const mediaUrls = (post: FeedPost, username: string): { chart: string | null; route: string | null } => {
+  const nativeChart =
+    post.structured?.kind === 'activity' && structuredChartSeries(post.structured).length > 0
+  return {
+    chart: post.include_chart && !nativeChart ? imageUrl(username, post, 'chart') : null,
+    route: post.include_map ? imageUrl(username, post, 'route') : null,
+  }
+}
+
+/**
  * Native body for an activity post with resolved typed metrics (#997): title,
  * personal message, the activity's own date (#998), and a stat grid — instead
  * of the flattened `content` HTML Mastodon sees.
@@ -74,15 +90,7 @@ export const FeedPostCard = ({
 }) => {
   const vis = VISIBILITY[post.visibility]
   const when = formatDistanceToNow(new Date(post.created_at), { addSuffix: true })
-  // The static chart.png is replaced only when the native interactive chart
-  // ACTUALLY renders — `structured` is attached to every activity post, so
-  // keying on its mere presence would drop the chart from an `include_chart`
-  // post whose series is empty/undrawable. The route map has no native render,
-  // so its image always stays.
-  const nativeChart =
-    post.structured?.kind === 'activity' && structuredChartSeries(post.structured).length > 0
-  const chart = post.include_chart && !nativeChart ? imageUrl(author.username, post, 'chart') : null
-  const route = post.include_map ? imageUrl(author.username, post, 'route') : null
+  const { chart, route } = mediaUrls(post, author.username)
 
   return (
     <article class="feed-post">

--- a/apps/web/src/pages/Feed/FeedPostCard.tsx
+++ b/apps/web/src/pages/Feed/FeedPostCard.tsx
@@ -16,6 +16,7 @@ import { API_URL } from '../../config'
 import { formatEntryWindow } from './activity-stats'
 import { ActivityStatGrid } from './ActivityStatGrid'
 import { ArticleContent } from './ArticleContent'
+import { structuredChartSeries } from './timeline-structured'
 import { TimelineStructured } from './TimelineStructured'
 import './FeedPostCard.css'
 
@@ -73,10 +74,14 @@ export const FeedPostCard = ({
 }) => {
   const vis = VISIBILITY[post.visibility]
   const when = formatDistanceToNow(new Date(post.created_at), { addSuffix: true })
-  // With the full structured payload the native interactive chart replaces the
-  // static chart.png (same rule as a peer's timeline card); the route map has
-  // no native render, so its image always stays.
-  const chart = post.include_chart && !post.structured ? imageUrl(author.username, post, 'chart') : null
+  // The static chart.png is replaced only when the native interactive chart
+  // ACTUALLY renders — `structured` is attached to every activity post, so
+  // keying on its mere presence would drop the chart from an `include_chart`
+  // post whose series is empty/undrawable. The route map has no native render,
+  // so its image always stays.
+  const nativeChart =
+    post.structured?.kind === 'activity' && structuredChartSeries(post.structured).length > 0
+  const chart = post.include_chart && !nativeChart ? imageUrl(author.username, post, 'chart') : null
   const route = post.include_map ? imageUrl(author.username, post, 'route') : null
 
   return (

--- a/apps/web/src/pages/Feed/FeedPostCard.tsx
+++ b/apps/web/src/pages/Feed/FeedPostCard.tsx
@@ -16,6 +16,7 @@ import { API_URL } from '../../config'
 import { formatEntryWindow } from './activity-stats'
 import { ActivityStatGrid } from './ActivityStatGrid'
 import { ArticleContent } from './ArticleContent'
+import { TimelineStructured } from './TimelineStructured'
 import './FeedPostCard.css'
 
 export interface PostAuthor {
@@ -72,7 +73,10 @@ export const FeedPostCard = ({
 }) => {
   const vis = VISIBILITY[post.visibility]
   const when = formatDistanceToNow(new Date(post.created_at), { addSuffix: true })
-  const chart = post.include_chart ? imageUrl(author.username, post, 'chart') : null
+  // With the full structured payload the native interactive chart replaces the
+  // static chart.png (same rule as a peer's timeline card); the route map has
+  // no native render, so its image always stays.
+  const chart = post.include_chart && !post.structured ? imageUrl(author.username, post, 'chart') : null
   const route = post.include_map ? imageUrl(author.username, post, 'route') : null
 
   return (
@@ -91,12 +95,16 @@ export const FeedPostCard = ({
       </header>
 
       {/* An article renders its own title + prose/chart blocks (prose sanitised
-          via the shared sanitiser). An activity post with resolved typed metrics
-          renders natively (`ActivityPostBody`). Older payloads without `metrics`
-          fall back to the server-built, HTML-escaped `content` (safe to render
-          directly). */}
+          via the shared sanitiser). An activity post with the full structured
+          payload renders the SAME `TimelineStructured` component a subscribing
+          Aurboda peer's home timeline uses (#1008) — interactive hover charts
+          included — so the owner sees exactly what a follower sees. Without it
+          (public profile), the stat-grid `ActivityPostBody`; older payloads
+          fall back to the server-built, HTML-escaped `content`. */}
       {post.kind === 'article' && post.article ? (
         <ArticleContent article={post.article} />
+      ) : post.structured ? (
+        <TimelineStructured structured={post.structured} />
       ) : post.metrics ? (
         <ActivityPostBody post={post} />
       ) : post.content ? (

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -15,6 +15,7 @@ import { useState } from 'preact/hooks'
 
 import { fetchTimeline } from '../../state/api'
 import { ActorName } from './ActorName'
+import { structuredChartSeries } from './timeline-structured'
 import { TimelineStructured } from './TimelineStructured'
 import { useTimelineLive } from './useTimelineLive'
 
@@ -86,13 +87,17 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
           otherwise fall back to the delivered image attachment(s), the way
           Mastodon shows them. An enriched *activity* post still shows its
           delivered route map — the structured payload has no native map render —
-          but skips the chart PNG the native interactive chart duplicates (the
-          attachment names are Aurboda's own, so matching on them is stable). */}
+          and skips the chart PNG only when the native interactive chart ACTUALLY
+          renders (an empty/undrawable series must not lose the chart entirely;
+          the attachment names are Aurboda's own, so matching on them is stable). */}
       {entry.structured && <TimelineStructured structured={entry.structured} />}
       {entry.images
-        ?.filter((img) =>
-          entry.structured == null ? true : entry.structured.kind === 'activity' && img.name !== 'Heart rate',
-        )
+        ?.filter((img) => {
+          if (entry.structured == null) return true
+          if (entry.structured.kind !== 'activity') return false
+          const nativeChart = structuredChartSeries(entry.structured).length > 0
+          return img.name !== 'Heart rate' || !nativeChart
+        })
         .map((img) => (
           <img
             key={img.url}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -458,9 +458,13 @@ resolving.
 - **Share** — an activity's detail page has a **Share to feed** button. It opens a dialog
   to write an optional personal message (prefilled from the activity's description /
   comments, fully editable), pick the summary metrics, optionally opt into full series,
-  and choose the audience. The user's own feed cards and public profile render the shared
-  scalars as a native **stat grid** (with the message and the activity's date) rather than
-  the flattened text Mastodon sees.
+  and choose the audience. The **owner's own feed** renders each activity post with the
+  **same native card component a subscribing Aurboda peer's timeline uses** — the owner-facing
+  feed responses include the full structured payload (typed scalars + inline series, assembled
+  by the same helper the public structured endpoint uses), so the author sees the interactive
+  hover charts exactly as a follower would, and can verify what they shared. The public
+  profile renders the lighter native **stat grid** (message + activity date + typed scalars)
+  without the series weight.
 - **New article** — the **Feed** page has a **New article** button that opens the article
   composer: a title, an optional default time window, and an ordered list of **prose**
   (markdown), **chart** (a metric + optional per-block window + caption), and **correlation**

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -295,10 +295,6 @@ export const feedPostSchema = z
       .array(feedStructuredMetricSchema)
       .optional()
       .meta({ description: 'Resolved typed scalar values for the shared metrics (activity posts)' }),
-    // The full native structured payload — the SAME payload a subscribing
-    // Aurboda peer fetches from the public structured endpoint — so the owner's
-    // own feed renders the identical native card component (#1008). Present
-    // only on the owner-facing feed surfaces, for `activity` posts.
     structured: feedStructuredPostSchema.optional().meta({
       description:
         "The post's native structured payload (typed metrics + inline series), identical to what a subscribing peer receives — drives the owner's native card render",

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -295,6 +295,14 @@ export const feedPostSchema = z
       .array(feedStructuredMetricSchema)
       .optional()
       .meta({ description: 'Resolved typed scalar values for the shared metrics (activity posts)' }),
+    // The full native structured payload — the SAME payload a subscribing
+    // Aurboda peer fetches from the public structured endpoint — so the owner's
+    // own feed renders the identical native card component (#1008). Present
+    // only on the owner-facing feed surfaces, for `activity` posts.
+    structured: feedStructuredPostSchema.optional().meta({
+      description:
+        "The post's native structured payload (typed metrics + inline series), identical to what a subscribing peer receives — drives the owner's native card render",
+    }),
     series_metrics: z.array(z.string()).meta({ description: 'Explicitly-shared series metrics' }),
     updated_at: z.string().meta({ description: 'Last update timestamp (ISO 8601)' }),
     visibility: feedVisibilitySchema,


### PR DESCRIPTION
Implements #1008 with the design Fredrik specified: **the own feed must look exactly like it would for another Aurboda subscriber — the same component displayed** — so the author can verify enrichment/native rendering from their own shares.

- **Shared assembly, zero drift:** new leaf module `feed-structured-activity.ts` (`resolveStructuredSeries` + `assembleStructuredActivity`), used by both the public structured endpoint (`feed-structured.ts`) and the owner serialisation — the payload a peer fetches and the payload the owner's card renders are assembled by the same code.
- **Owner-facing opt-in:** `serializeFeedPost(user, record, { includeStructured: true })` on `GET /feed` and the share/PATCH responses attaches the full `FeedPost.structured` (typed scalars + inline series, reusing the already-resolved scalars — only the series query is new). Public profile listing and MCP tools stay lightweight (no series payload).
- **Web:** `FeedPostCard` renders `post.structured` with **`TimelineStructured`** — the identical component the home timeline uses for a peer's post — giving the interactive hover chart natively; the static `chart.png` is dropped when the native chart renders (same rule as the peer timeline), the `route.png` stays (no native map render yet). The stat-grid body remains as the fallback for structured-less surfaces.
- Integration test: payload present/absent per flag, `structured.metrics` ≡ flat `metrics`, message carried, empty-series shape.

Out of scope (left in #1008/#996 follow-up space): interactive pan/zoom **map** (needs a native map component on the card), and article posts (their own card already renders the native `ArticleContent`).

Closes #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo