### PR TITLE
fix(feed): timeline enrichment — local-origin resolution, failure logging, lazy retro-enrichment (#996)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -42,9 +42,11 @@ import {
   insertPlace,
   insertRawRecord,
   insertTimeSeries,
+  listUnenrichedAurbodaEntries,
   loginToUserDb,
   openTimelineChannel,
   resolveOrCreateActivityType,
+  setTimelineEntryStructured,
   softDeleteSupersededLocations,
   updateDetectedLocation,
   upsertSyncState,
@@ -67,6 +69,7 @@ import {
 } from './services/activitypub/deliver.ts'
 import { createFeedFederation } from './services/activitypub/federation.ts'
 import { createTimelineBackfiller } from './services/activitypub/timeline-backfill.ts'
+import { createAurbodaEnricher } from './services/activitypub/timeline-enrich.ts'
 import { auditError, auditInfo } from './services/audit-log.ts'
 import { triggerCalorieComputation } from './services/calorie-computation.ts'
 import { createCalorieQueue, type CalorieQueue } from './services/calorie-queue.ts'
@@ -97,6 +100,7 @@ import { initSentry, Sentry } from './services/sentry.ts'
 import { createStravaQueue, type StravaQueue } from './services/strava-queue.ts'
 import { createSyncProvider } from './services/sync-provider.ts'
 import { createTimelineHub } from './services/timeline-hub.ts'
+import { retroEnrichTimelineEntries } from './services/timeline-retro-enrich.ts'
 import { createWebAuthnService } from './services/webauthn.ts'
 
 /** Grace period for in-flight requests before sockets are forced closed. */
@@ -353,6 +357,18 @@ const main = async () => {
   )
   const backfill = createTimelineBackfiller(feedFederation, webHost)
   const feedDeps = { apiBaseUrl, federation: feedFederation, origin: webHost }
+
+  // Lazy retro-enrichment (#996): entries ingested before structured enrichment
+  // shipped (or whose ingest-time enrichment failed transiently) get one more
+  // attempt when the timeline is read. Fire-and-forget — never blocks a read.
+  const retroEnricher = createAurbodaEnricher(webHost)
+  const retroEnrichTimeline = (user: string) => {
+    void retroEnrichTimelineEntries(user, {
+      enrich: retroEnricher,
+      listUnenriched: listUnenrichedAurbodaEntries,
+      save: setTimelineEntryStructured,
+    }).catch((err: unknown) => console.warn(`⚠️ timeline retro-enrichment failed for ${user}:`, err))
+  }
   const onDeliverError = (op: string, user: string, postId: string) => (err: unknown) =>
     console.error(`⚠️ feed ${op} delivery failed for ${user}/${postId}:`, err)
   const feedDeliver: FeedDeliver = {
@@ -424,6 +440,7 @@ const main = async () => {
       garmin,
       onActivityMutated: activityNotifier,
       oura,
+      retroEnrichTimeline,
       stravaQueue: stravaQueue ?? undefined,
       sync: syncProvider,
       webHost,
@@ -564,6 +581,7 @@ const main = async () => {
     httpd,
     invitationAuth,
     ouraWebhookManager,
+    retroEnrichTimeline,
     syncProvider,
     timelineHub,
     userDb,

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -102,6 +102,8 @@ interface RestRoutesDeps {
   followActions: FollowActions
   followerActions: FollowerActions
   timelineHub: TimelineHub
+  /** Fire-and-forget lazy retro-enrichment of timeline entries on read (#996). */
+  retroEnrichTimeline: (user: string) => void
 }
 
 export const mountRestRouters = ({
@@ -121,6 +123,7 @@ export const mountRestRouters = ({
   feedDeliver,
   followActions,
   followerActions,
+  retroEnrichTimeline,
   timelineHub,
   ouraWebhookManager,
   auth,
@@ -168,7 +171,10 @@ export const mountRestRouters = ({
   // feed router's `/:postId`.
   httpd.use('/feed/following', createFeedFollowingRouter(authMiddleware, followActions))
   httpd.use('/feed/followers', createFeedFollowersRouter(authMiddleware, followerActions))
-  httpd.use('/feed', createFeedRouter(authMiddleware, feedDeliver, timelineHub, apiBaseUrl))
+  httpd.use(
+    '/feed',
+    createFeedRouter(authMiddleware, feedDeliver, timelineHub, apiBaseUrl, retroEnrichTimeline),
+  )
   httpd.use('/challenges', createChallengesRouter(authMiddleware, webHost, apiBaseUrl))
   httpd.use(createChallengeDataRouter())
   // Public feed series must be mounted before the generic /public/:username/:slug

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -310,9 +310,12 @@ export {
   deleteTimelineEntriesByActor,
   deleteTimelineEntryByUri,
   listTimelineEntries,
+  listUnenrichedAurbodaEntries,
+  setTimelineEntryStructured,
   type TimelineCursor,
   type TimelineEntryInput,
   type TimelineEntryRecord,
+  type UnenrichedTimelineEntry,
   upsertTimelineEntry,
 } from './timeline.ts'
 export { emitTimelineNotify, openTimelineChannel } from './timeline-notify.ts'

--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -9,6 +9,8 @@ import {
   deleteTimelineEntriesByActor,
   deleteTimelineEntryByUri,
   listTimelineEntries,
+  listUnenrichedAurbodaEntries,
+  setTimelineEntryStructured,
   type TimelineEntryInput,
   upsertTimelineEntry,
 } from './timeline.ts'
@@ -181,6 +183,50 @@ describe('Timeline store integration', () => {
     expect((await listTimelineEntries(user, 10)).map((e) => e.object_uri)).toEqual([
       'https://mastodon.example/notes/1',
     ])
+  })
+
+  test('retro-enrichment: lists Aurboda-shaped unenriched entries, marks attempts (#996)', async () => {
+    const user = getTestUser()
+    const structured = {
+      activity_type: 'exercise',
+      kind: 'activity' as const,
+      metrics: [{ key: 'distance', unit: 'km', value: 5 }],
+      series: [],
+      start_time: '2026-07-01T08:00:00.000Z',
+    }
+    const aurbodaUri = (n: number) =>
+      `https://peer.example/users/bob/feed/00000000-0000-4000-8000-00000000000${n}`
+    // 1: Aurboda-shaped, unenriched → candidate. 2: Mastodon → never a candidate.
+    // 3: Aurboda-shaped but already enriched → not a candidate.
+    const one = await upsertTimelineEntry(user, entry(1, { object_uri: aurbodaUri(1) }))
+    await upsertTimelineEntry(user, entry(2))
+    await upsertTimelineEntry(user, entry(3, { object_uri: aurbodaUri(3), structured }))
+
+    const candidates = await listUnenrichedAurbodaEntries(user, 10)
+    expect(candidates.map((c) => c.object_uri)).toEqual([aurbodaUri(1)])
+
+    // A failed attempt (null) stamps the entry without inventing a payload…
+    await setTimelineEntryStructured(user, one.id, null)
+    expect(await listUnenrichedAurbodaEntries(user, 10)).toEqual([])
+    expect((await listTimelineEntries(user, 10)).find((e) => e.id === one.id)?.structured).toBeNull()
+
+    // …and a successful one stores it (visible on the next read).
+    await setTimelineEntryStructured(user, one.id, structured)
+    expect((await listTimelineEntries(user, 10)).find((e) => e.id === one.id)?.structured).toEqual(structured)
+  })
+
+  test('retro-enrichment: setTimelineEntryStructured never wipes an existing payload with null', async () => {
+    const user = getTestUser()
+    const structured = {
+      activity_type: 'exercise',
+      kind: 'activity' as const,
+      metrics: [],
+      series: [],
+      start_time: '2026-07-01T08:00:00.000Z',
+    }
+    const rec = await upsertTimelineEntry(user, entry(1, { structured }))
+    await setTimelineEntryStructured(user, rec.id, null)
+    expect((await listTimelineEntries(user, 10))[0].structured).toEqual(structured)
   })
 
   test('purges every entry from an actor (on unfollow)', async () => {

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -154,3 +154,53 @@ export const deleteTimelineEntriesByActor = async (user: string, actorUri: strin
   const result = await query(user, `DELETE FROM timeline_entry WHERE actor_uri = $1`, [actorUri])
   return result.rowCount ?? 0
 }
+
+/** The fields a lazy retro-enrichment attempt needs (#996). */
+export interface UnenrichedTimelineEntry {
+  id: string
+  object_uri: string
+  images: TimelineImage[] | null
+}
+
+/**
+ * Aurboda-shaped entries with no structured payload and no retro-enrichment
+ * attempt yet, newest first (#996): entries ingested before enrichment shipped,
+ * or whose ingest-time enrichment failed transiently. The LIKE is a coarse SQL
+ * prefilter — the service re-validates with `parseAurbodaFeedUrl` before
+ * fetching anything.
+ */
+export const listUnenrichedAurbodaEntries = async (
+  user: string,
+  limit: number,
+): Promise<UnenrichedTimelineEntry[]> => {
+  const result = await query<UnenrichedTimelineEntry>(
+    user,
+    `SELECT id, object_uri, images FROM timeline_entry
+     WHERE structured IS NULL AND enrich_attempted_at IS NULL
+       AND object_uri LIKE '%/users/%/feed/%'
+     ORDER BY published_at DESC, id DESC
+     LIMIT $1`,
+    [limit],
+  )
+  return result.rows
+}
+
+/**
+ * Record a retro-enrichment attempt (#996): store the payload when one was
+ * obtained (never overwrite an existing one with NULL) and stamp
+ * `enrich_attempted_at` either way, so an entry is retried at most once — a
+ * later `Update` redelivery still re-enriches through the ingest path.
+ */
+export const setTimelineEntryStructured = async (
+  user: string,
+  id: string,
+  structured: FeedStructuredPost | null,
+): Promise<void> => {
+  await query(
+    user,
+    `UPDATE timeline_entry
+     SET structured = COALESCE($2, structured), enrich_attempted_at = NOW()
+     WHERE id = $1`,
+    [id, structured == null ? null : JSON.stringify(structured)],
+  )
+}

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -64,6 +64,8 @@ interface McpDeps {
   garmin?: GarminClient
   onActivityMutated?: ActivityNotifier
   oura?: OuraClientType
+  /** Fire-and-forget lazy retro-enrichment of timeline entries on read (#996). */
+  retroEnrichTimeline?: (user: string) => void
   stravaQueue?: StravaQueue
   sync?: SyncProvider
   webHost?: string
@@ -99,7 +101,15 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
   }
   registerReportTools(server, user)
   registerSharedDashboardTools(server, user)
-  registerFeedTools(server, user, deps.feedDeliver, deps.followActions, deps.followerActions, deps.apiBaseUrl)
+  registerFeedTools(
+    server,
+    user,
+    deps.feedDeliver,
+    deps.followActions,
+    deps.followerActions,
+    deps.apiBaseUrl,
+    deps.retroEnrichTimeline,
+  )
   registerChallengeTools(server, user, { apiBaseUrl: deps.apiBaseUrl, webHost: deps.webHost })
   registerScreentimeCategoryTools(server, user)
   registerDebugTools(server, user)

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -55,6 +55,8 @@ export const registerFeedTools = (
   followActions?: FollowActions,
   followerActions?: FollowerActions,
   apiBaseUrl?: string,
+  /** Fire-and-forget lazy retro-enrichment of timeline entries on read (#996). */
+  retroEnrichTimeline?: (user: string) => void,
 ) => {
   server.tool(
     'list_feed',
@@ -206,7 +208,12 @@ export const registerFeedTools = (
     'list_timeline',
     'List your home timeline: posts received from the actors you follow, newest first. Pass `cursor` (from a previous call) to page.',
     { ...timelineQuerySchema.shape },
-    async ({ cursor, limit }) => jsonResponse(await getTimelinePage(user, limit, cursor)),
+    async ({ cursor, limit }) => {
+      const page = await getTimelinePage(user, limit, cursor)
+      // Same lazy retro-enrichment kick as the REST timeline read (#996).
+      retroEnrichTimeline?.(user)
+      return jsonResponse(page)
+    },
   )
 
   server.tool(

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -75,6 +75,8 @@ export const createFeedRouter = (
   deliver?: FeedDeliver,
   hub?: TimelineHub,
   apiBaseUrl?: string,
+  /** Fire-and-forget lazy retro-enrichment of timeline entries on read (#996). */
+  retroEnrichTimeline?: (user: string) => void,
 ): TypedRouter => {
   const router = typedRouter()
 
@@ -145,6 +147,10 @@ export const createFeedRouter = (
     async (req, res) => {
       const user = req.user!
       const { entries, next_cursor } = await getTimelinePage(user, req.query.limit, req.query.cursor)
+      // Kick a lazy retro-enrichment pass for entries still missing their native
+      // payload (#996) — fire-and-forget, the current response is not delayed;
+      // enriched entries render natively on the next read.
+      retroEnrichTimeline?.(user)
       res.json({ entries, next_cursor, success: true })
     },
   )

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -154,6 +154,7 @@ export const tableCreationOrder = [
   'timeline_entry',
   'timeline_entry_structured',
   'timeline_entry_images',
+  'timeline_entry_enrich_attempted',
   'timeline_entry_indexes',
   'profile_avatar',
   'mcp_sessions',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -262,7 +262,12 @@ export const socialTables: Record<string, string> = {
       structured    JSONB,
       -- Image attachments (rendered chart / route map, or a Mastodon photo)
       -- captured from the delivered Note; shown when there's no native chart.
-      images        JSONB
+      images        JSONB,
+      -- When a lazy retro-enrichment attempt ran for this entry (#996). NULL
+      -- means eligible: an Aurboda-shaped entry with NULL structured gets one
+      -- retry on timeline read (covers pre-enrichment entries and transient
+      -- ingest-time failures), then is marked here regardless of outcome.
+      enrich_attempted_at TIMESTAMPTZ
     )
   `,
   // Additive columns for DBs created before the structured-timeline / media features.
@@ -271,6 +276,9 @@ export const socialTables: Record<string, string> = {
   `,
   timeline_entry_images: `
     ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS images JSONB
+  `,
+  timeline_entry_enrich_attempted: `
+    ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS enrich_attempted_at TIMESTAMPTZ
   `,
   // Timeline ordering / keyset pagination is by (published_at DESC, id DESC).
   timeline_entry_indexes: `

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -233,7 +233,7 @@ export const createFeedFederation = (
 
   // Fetches native structured data (typed metrics + series) for ingested posts
   // that come from Aurboda instances, so the web can render a native chart.
-  const enrich = createAurbodaEnricher()
+  const enrich = createAurbodaEnricher(origin)
 
   federation
     .setActorDispatcher('/users/{identifier}', async (ctx, identifier) => {

--- a/apps/backend/src/services/activitypub/timeline-backfill.ts
+++ b/apps/backend/src/services/activitypub/timeline-backfill.ts
@@ -123,7 +123,7 @@ export const createTimelineBackfiller = (
   federation: Federation<void>,
   origin: string,
 ): ((user: string, actorUri: string) => void) => {
-  const enrich = createAurbodaEnricher()
+  const enrich = createAurbodaEnricher(origin)
   const deps: BackfillDeps = {
     fetchRecentNotes: (actorUri, limit) => fetchRecentOutboxNotes(federation, origin, actorUri, limit),
     getFollowee: getFeedFollowingByActor,

--- a/apps/backend/src/services/activitypub/timeline-enrich.test.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.test.ts
@@ -104,14 +104,16 @@ describe('enrichFromAurboda', () => {
     expect(fetched).toBe(false)
   })
 
-  test('returns null when the host does not federate (discover throws)', async () => {
+  test('propagates a discovery failure so the caller can log it (#996)', async () => {
     const deps: AurbodaEnrichDeps = {
       discover: async () => {
         throw new Error('not an Aurboda host')
       },
       fetchStructured: async () => ({ structured, success: true }),
     }
-    expect(await enrichFromAurboda(`https://mastodon.social/users/a/feed/${UUID}`, deps)).toBeNull()
+    await expect(enrichFromAurboda(`https://mastodon.social/users/a/feed/${UUID}`, deps)).rejects.toThrow(
+      'not an Aurboda host',
+    )
   })
 
   test('returns null when the response has no structured payload (404-style body)', async () => {
@@ -122,12 +124,57 @@ describe('enrichFromAurboda', () => {
     expect(await enrichFromAurboda(`https://aurboda.net/users/fredrik/feed/${UUID}`, deps)).toBeNull()
   })
 
-  test('returns null when the response is malformed (schema mismatch)', async () => {
+  test('throws on a malformed response (schema mismatch) so the caller can log it (#996)', async () => {
     const deps: AurbodaEnrichDeps = {
       discover: async () => wellKnown,
       fetchStructured: async () => ({ structured: { nope: true }, success: true }),
     }
-    expect(await enrichFromAurboda(`https://aurboda.net/users/fredrik/feed/${UUID}`, deps)).toBeNull()
+    await expect(enrichFromAurboda(`https://aurboda.net/users/fredrik/feed/${UUID}`, deps)).rejects.toThrow(
+      'malformed structured response',
+    )
+  })
+
+  test('resolves a SAME-instance post in-process — no discovery, no HTTP (#996)', async () => {
+    const calls: string[] = []
+    const deps: AurbodaEnrichDeps = {
+      discover: async () => {
+        calls.push('discover')
+        return wellKnown
+      },
+      fetchStructured: async () => {
+        calls.push('fetch')
+        return { structured, success: true }
+      },
+      local: {
+        // Trailing slash exercises the origin normalisation.
+        origin: 'https://aurboda.net/',
+        resolve: async (user, postId, token) => {
+          calls.push(`local:${user}/${postId}?token=${token ?? ''}`)
+          return structured
+        },
+      },
+    }
+    const result = await enrichFromAurboda(`https://aurboda.net/users/fredrik/feed/${UUID}`, deps, 'tok')
+    expect(result).toEqual(structured)
+    expect(calls).toEqual([`local:fredrik/${UUID}?token=tok`])
+  })
+
+  test('a DIFFERENT origin still goes over HTTP despite the local shortcut', async () => {
+    let local = false
+    const deps: AurbodaEnrichDeps = {
+      discover: async () => wellKnown,
+      fetchStructured: async () => ({ structured, success: true }),
+      local: {
+        origin: 'https://aurboda.net',
+        resolve: async () => {
+          local = true
+          return null
+        },
+      },
+    }
+    const result = await enrichFromAurboda(`https://other.example/users/bob/feed/${UUID}`, deps)
+    expect(result).toEqual(structured)
+    expect(local).toBe(false)
   })
 
   test('passes the capability token as ?token= so a followers-only post authorizes', async () => {

--- a/apps/backend/src/services/activitypub/timeline-enrich.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.ts
@@ -11,11 +11,18 @@
  * - Only Notes whose id matches Aurboda's own object-dispatcher path
  *   (`/users/{user}/feed/{postId}`) are candidates — a Mastodon status id never
  *   matches, so no needless fetch is made for non-Aurboda posts.
- * - The fetch goes through `safeFetchGet` (SSRF-guarded: public hosts only, no
- *   redirects, size + time bounded) and the origin is the *accepted followee's*
- *   host (already validated by `noteToTimelineInput`), not an arbitrary target.
- * - Any failure (non-Aurboda host, 404, malformed body, timeout) resolves to
- *   `null`; the post still shows with its HTML.
+ * - A post whose origin IS this instance (a local-to-local follow) resolves
+ *   **in-process** via the same `resolveStructuredPost` the public endpoint
+ *   serves — an HTTP fetch of our own public origin would hairpin through the
+ *   reverse proxy and, from inside the container, typically resolve to a
+ *   private address the SSRF guard rightly refuses (#996).
+ * - A remote fetch goes through `safeFetchGet` (SSRF-guarded: public hosts
+ *   only, no redirects, size + time bounded) and the origin is the *accepted
+ *   followee's* host (already validated by `noteToTimelineInput`).
+ * - Any failure (non-federating host, 404, malformed body, timeout) resolves to
+ *   `null` — the post still shows with its HTML — but is LOGGED by the default
+ *   enricher, so a broken enrichment path is diagnosable instead of looking
+ *   identical to a Mastodon post (#996).
  *
  * The network dependencies are injected so the mapping is unit-testable offline.
  */
@@ -27,6 +34,7 @@ import {
 } from '@aurboda/api-spec'
 
 import { discoverInstance } from '../challenge-federation.ts'
+import { resolveStructuredPost } from '../feed-structured.ts'
 import { safeFetchGet } from '../safe-fetch.ts'
 import { withTimeout } from '../with-timeout.ts'
 
@@ -61,6 +69,16 @@ export interface AurbodaEnrichDeps {
   discover: (base: string) => Promise<WellKnownAurboda>
   /** Fetch + JSON-decode a public URL (SSRF-guarded). */
   fetchStructured: (url: string) => Promise<unknown>
+  /**
+   * Same-instance shortcut: when the object's origin IS this instance, resolve
+   * the payload in-process instead of HTTP-fetching our own public URL (which
+   * would hairpin through the proxy and trip the SSRF guard on the private
+   * address it resolves to from inside the container).
+   */
+  local?: {
+    origin: string
+    resolve: (user: string, postId: string, token?: string) => Promise<FeedStructuredPost | null>
+  }
 }
 
 const trimSlashes = (s: string): string => s.replace(/\/+$/, '')
@@ -85,8 +103,12 @@ export const capabilityTokenFrom = (images: TimelineImage[]): string | undefined
 }
 
 /**
- * Fetch the structured payload for an Aurboda feed-post object URI, or null if
- * the post isn't an Aurboda post, the host doesn't federate, or anything fails.
+ * Fetch the structured payload for an Aurboda feed-post object URI. Returns
+ * `null` when the URI isn't Aurboda-shaped (a Mastodon status — the common,
+ * silent case) or when the origin answers without a payload (post gone, or a
+ * `followers`-only post without a valid token). THROWS on everything else —
+ * failed discovery, unreachable host, malformed body — so the caller can log
+ * the reason; the plain `enrichFromAurboda` never swallows.
  * `token` (lifted from the delivered image URL) authorizes a `followers`-only
  * post; a public post needs none.
  */
@@ -97,39 +119,49 @@ export const enrichFromAurboda = async (
 ): Promise<FeedStructuredPost | null> => {
   const parsed = parseAurbodaFeedUrl(objectUri)
   if (parsed == null) return null
-  try {
-    const wellKnown = await deps.discover(parsed.origin)
-    const base = `${trimSlashes(wellKnown.api_base)}/public/${encodeURIComponent(parsed.user)}/feed/${parsed.postId}`
-    const url = token == null ? base : `${base}?token=${encodeURIComponent(token)}`
-    const body = await deps.fetchStructured(url)
-    const result = feedPostStructuredResponseSchema.safeParse(body)
-    if (!result.success || !result.data.structured) return null
-    return result.data.structured
-  } catch {
-    return null
+  if (deps.local && parsed.origin === trimSlashes(deps.local.origin)) {
+    return deps.local.resolve(parsed.user, parsed.postId, token)
   }
+  const wellKnown = await deps.discover(parsed.origin)
+  const base = `${trimSlashes(wellKnown.api_base)}/public/${encodeURIComponent(parsed.user)}/feed/${parsed.postId}`
+  const url = token == null ? base : `${base}?token=${encodeURIComponent(token)}`
+  const body = await deps.fetchStructured(url)
+  const result = feedPostStructuredResponseSchema.safeParse(body)
+  if (!result.success) throw new Error('malformed structured response')
+  return result.data.structured ?? null
 }
 
 /** Total time budget for one post's enrichment (discovery + structured fetch). */
 const ENRICH_TIMEOUT_MS = 12_000
 
+/** An enricher: object URI (+ optional capability token) → structured payload or null. */
+export type TimelineEnricher = (objectUri: string, token?: string) => Promise<FeedStructuredPost | null>
+
 /**
- * The default enricher wired into the inbox handler: real discovery + guarded
- * fetch, bounded by a total timeout so a slow peer can't stall ingest, and
- * swallowing every error to `null` (enrichment is never allowed to fail ingest).
+ * The default enricher wired into the inbox handler: in-process resolution for
+ * this instance's own posts (`origin` is our public web origin), real discovery
+ * + guarded fetch for remote peers, bounded by a total timeout so a slow peer
+ * can't stall ingest. Every error still resolves to `null` (enrichment is never
+ * allowed to fail ingest) but is logged first — an Aurboda-shaped post that
+ * loses its native chart must be visible in the logs, not indistinguishable
+ * from a Mastodon post (#996).
  */
-export const createAurbodaEnricher = (): ((
-  objectUri: string,
-  token?: string,
-) => Promise<FeedStructuredPost | null>) => {
+export const createAurbodaEnricher = (origin: string): TimelineEnricher => {
   const deps: AurbodaEnrichDeps = {
     discover: discoverInstance,
     fetchStructured: async (url) => (await safeFetchGet(url)).data,
+    local: { origin, resolve: resolveStructuredPost },
   }
   return async (objectUri, token) => {
+    if (parseAurbodaFeedUrl(objectUri) == null) return null
     try {
-      return await withTimeout(enrichFromAurboda(objectUri, deps, token), ENRICH_TIMEOUT_MS)
-    } catch {
+      const structured = await withTimeout(enrichFromAurboda(objectUri, deps, token), ENRICH_TIMEOUT_MS)
+      if (structured == null) {
+        console.warn(`⚠️ timeline enrichment: no payload for ${objectUri} (post gone or unauthorized)`)
+      }
+      return structured
+    } catch (error) {
+      console.warn(`⚠️ timeline enrichment failed for ${objectUri}:`, error)
       return null
     }
   }

--- a/apps/backend/src/services/timeline-retro-enrich.test.ts
+++ b/apps/backend/src/services/timeline-retro-enrich.test.ts
@@ -1,0 +1,85 @@
+import type { FeedStructuredPost } from '@aurboda/api-spec'
+
+import { describe, expect, test } from 'vitest'
+
+import type { UnenrichedTimelineEntry } from '../db/index.ts'
+
+import { type RetroEnrichDeps, retroEnrichTimelineEntries } from './timeline-retro-enrich.ts'
+
+const UUID = '11111111-2222-4333-8444-555555555555'
+
+const structured: FeedStructuredPost = {
+  activity_type: 'exercise',
+  kind: 'activity',
+  metrics: [],
+  series: [],
+  start_time: '2026-07-01T08:00:00.000Z',
+}
+
+const aurbodaEntry = (id: string, images: UnenrichedTimelineEntry['images'] = null): UnenrichedTimelineEntry => ({
+  id,
+  images,
+  object_uri: `https://peer.example/users/bob/feed/${UUID}`,
+})
+
+const deps = (
+  entries: UnenrichedTimelineEntry[],
+  enrichResult: FeedStructuredPost | null,
+): RetroEnrichDeps & { enriched: string[]; saved: [string, FeedStructuredPost | null][] } => {
+  const enriched: string[] = []
+  const saved: [string, FeedStructuredPost | null][] = []
+  return {
+    enrich: async (uri, token) => {
+      enriched.push(`${uri}?token=${token ?? ''}`)
+      return enrichResult
+    },
+    enriched,
+    listUnenriched: async (_user, limit) => entries.slice(0, limit),
+    save: async (_user, id, payload) => {
+      saved.push([id, payload])
+    },
+    saved,
+  }
+}
+
+describe('retroEnrichTimelineEntries', () => {
+  test('enriches eligible entries and stores the payload', async () => {
+    const d = deps([aurbodaEntry('a'), aurbodaEntry('b')], structured)
+    expect(await retroEnrichTimelineEntries('u', d)).toBe(2)
+    expect(d.saved).toEqual([
+      ['a', structured],
+      ['b', structured],
+    ])
+  })
+
+  test('stamps a failed attempt (null) so the entry is not retried forever', async () => {
+    const d = deps([aurbodaEntry('a')], null)
+    expect(await retroEnrichTimelineEntries('u', d)).toBe(0)
+    expect(d.saved).toEqual([['a', null]])
+  })
+
+  test('lifts the capability token from the stored images (followers-only posts)', async () => {
+    const images = [{ url: 'https://peer.example/api/public/bob/feed/x/chart.png?token=sekrit' }]
+    const d = deps([aurbodaEntry('a', images)], structured)
+    await retroEnrichTimelineEntries('u', d)
+    expect(d.enriched).toEqual([`https://peer.example/users/bob/feed/${UUID}?token=sekrit`])
+  })
+
+  test('stamps (without fetching) an entry the SQL prefilter matched but that is not an Aurboda object', async () => {
+    const notAurboda: UnenrichedTimelineEntry = {
+      id: 'weird',
+      images: null,
+      object_uri: 'https://mastodon.example/users/a/feed/not-a-uuid',
+    }
+    const d = deps([notAurboda], structured)
+    expect(await retroEnrichTimelineEntries('u', d)).toBe(0)
+    expect(d.enriched).toEqual([])
+    expect(d.saved).toEqual([['weird', null]])
+  })
+
+  test('respects the batch size', async () => {
+    const d = deps([aurbodaEntry('a'), aurbodaEntry('b'), aurbodaEntry('c')], structured)
+    expect(await retroEnrichTimelineEntries('u', d, 2)).toBe(2)
+    expect(d.saved.map(([id]) => id)).toEqual(['a', 'b'])
+  })
+})

--- a/apps/backend/src/services/timeline-retro-enrich.ts
+++ b/apps/backend/src/services/timeline-retro-enrich.ts
@@ -1,0 +1,55 @@
+/**
+ * Lazy retro-enrichment of home-timeline entries (#996).
+ *
+ * Structured enrichment normally happens on ingest, so entries received before
+ * enrichment shipped — or whose ingest-time enrichment failed transiently —
+ * keep `structured = NULL` forever and render as flat HTML/PNG. When the
+ * timeline is read, this gives a small batch of such Aurboda-shaped entries one
+ * more attempt (newest first), fire-and-forget from the read path.
+ *
+ * Each entry is attempted at most once: `enrich_attempted_at` is stamped
+ * whether or not a payload was obtained (an `Update` redelivery still
+ * re-enriches through the ingest path). Dependencies are injected so the batch
+ * logic is unit-testable offline.
+ */
+import type { FeedStructuredPost } from '@aurboda/api-spec'
+
+import type { UnenrichedTimelineEntry } from '../db/index.ts'
+
+import { capabilityTokenFrom, parseAurbodaFeedUrl } from './activitypub/timeline-enrich.ts'
+
+/** Attempts per timeline read — enough to drain a backlog over a few visits without stalling anything. */
+const RETRO_BATCH_SIZE = 3
+
+export interface RetroEnrichDeps {
+  listUnenriched: (user: string, limit: number) => Promise<UnenrichedTimelineEntry[]>
+  /** Store the payload (or just stamp the attempt when null) for one entry. */
+  save: (user: string, id: string, structured: FeedStructuredPost | null) => Promise<void>
+  enrich: (objectUri: string, token?: string) => Promise<FeedStructuredPost | null>
+}
+
+/**
+ * Give up to `batchSize` eligible entries one enrichment attempt each,
+ * sequentially (a read should trigger a trickle, not a burst against a peer).
+ * Returns how many entries actually gained a payload.
+ */
+export const retroEnrichTimelineEntries = async (
+  user: string,
+  deps: RetroEnrichDeps,
+  batchSize: number = RETRO_BATCH_SIZE,
+): Promise<number> => {
+  const candidates = await deps.listUnenriched(user, batchSize)
+  let enriched = 0
+  for (const entry of candidates) {
+    // The SQL LIKE is a coarse prefilter — skip (and stamp) anything that isn't
+    // actually an Aurboda feed object, so it never comes back as a candidate.
+    if (parseAurbodaFeedUrl(entry.object_uri) == null) {
+      await deps.save(user, entry.id, null)
+      continue
+    }
+    const structured = await deps.enrich(entry.object_uri, capabilityTokenFrom(entry.images ?? []))
+    await deps.save(user, entry.id, structured)
+    if (structured != null) enriched++
+  }
+  return enriched
+}

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -309,10 +309,16 @@ structured data out-of-band on ingest:
    as a `Note` and the object id doesn't distinguish them. For a `followers`-only post it lifts
    the capability token from the delivered image URL (the `?token=` embedded only in the
    follower's `Note`) and forwards it, so an accepted follower fetches the native payload while a
-   public guess still 404s. All fetches are **SSRF-guarded** (`safe-fetch`: public hosts only, no
-   redirects, size + time bounded) and time-boxed; the origin is the accepted followee's own
-   host. Any failure (non-Aurboda host, 404, malformed, timeout) is swallowed — the post still
-   shows with its HTML.
+   public guess still 404s. A post whose origin is **this instance itself** (a local-to-local
+   follow) skips discovery and HTTP entirely and resolves **in-process** through the same
+   `resolveStructuredPost` the endpoint serves — fetching our own public origin would hairpin
+   through the reverse proxy and, from inside the container, typically resolve to a private
+   address the SSRF guard rightly refuses (#996). Remote fetches are **SSRF-guarded**
+   (`safe-fetch`: public hosts only, no redirects, size + time bounded) and time-boxed; the
+   origin is the accepted followee's own host. Any failure (non-Aurboda host, 404, malformed,
+   timeout) still resolves to "no payload" — the post shows with its HTML — but is **logged**,
+   so a broken enrichment path is diagnosable instead of looking identical to a Mastodon post
+   (#996).
 3. **Store + render.** The payload is stored on `timeline_entry.structured` (JSONB, NULL for
    non-Aurboda posts; a redelivery that can't re-fetch keeps the last-known value). The web
    timeline card renders, per `structured.kind`: for an **activity** post the native
@@ -329,6 +335,15 @@ Enrichment is strictly best-effort and additive: it never blocks or fails basic 
 activity's series that weren't shared (the opt-in) simply produce no chart, and an article's
 chart/correlation block with too little data renders the same "not enough data" fallback the
 author's own live render shows.
+
+**Lazy retro-enrichment (#996).** Entries ingested before enrichment shipped — or whose
+ingest-time enrichment failed transiently — would otherwise keep `structured = NULL` forever.
+Reading the timeline (REST `GET /feed/timeline` or the `list_timeline` MCP tool) kicks a
+fire-and-forget pass that gives a small batch (3, newest first) of such Aurboda-shaped entries
+one more attempt through the same enricher, stamping `enrich_attempted_at` win or lose so each
+entry is retried at most once — an `Update` redelivery still re-enriches through the normal
+ingest path. The read itself is never delayed; entries that gain a payload render natively on
+the next load.
 
 ### Live updates
 


### PR DESCRIPTION
Closes #996

Aurboda→Aurboda activity shares were documented to render native hover charts in the home timeline but observably did not (issue #996). This addresses all three suspected causes:

## 1. Same-instance posts resolve in-process (the likely production bug)
The enricher HTTP-fetched **even our own public origin**. From inside the container that hairpins through nginx and typically resolves to a private address, which the `safe-fetch` SSRF guard rightly refuses — so **every local-to-local follow lost its enrichment, silently**. `createAurbodaEnricher(origin)` now short-circuits objects on this instance's own origin to `resolveStructuredPost` — the exact function the public endpoint serves (capability-token check for `followers`-only included), so no drift, no discovery, no HTTP.

## 2. Enrichment failures are logged
`enrichFromAurboda` no longer swallows errors internally; the default enricher still resolves every failure to `null` (enrichment is never allowed to fail ingest) but logs it first — including the "answered but no payload" case — so a broken enrichment path stops being indistinguishable from a Mastodon post. Non-Aurboda-shaped URIs stay silent (no log spam for every Mastodon post).

## 3. Lazy retro-enrichment on timeline read (cause 2 from the issue)
Entries ingested before enrichment shipped — or whose ingest-time attempt failed transiently — kept `structured = NULL` forever. Reading the timeline (REST `GET /feed/timeline` **and** MCP `list_timeline`) now kicks a fire-and-forget pass giving 3 such Aurboda-shaped entries (newest first) one more attempt, stamping the new `timeline_entry.enrich_attempted_at` column win or lose so each entry is retried at most once; an `Update` redelivery still re-enriches through the normal ingest path. The read itself is never delayed. So Fredrik's existing pre-enrichment timeline entries gain their charts over a few page loads, with no manual backfill.

Re cause 1 (no series opted in → no chart by design): since #1013 an enriched activity card already renders the native stat grid + date + message even with zero series, so an Aurboda card visibly differs from a Mastodon one regardless.

## Notes
- Schema: additive `enrich_attempted_at TIMESTAMPTZ` column, registered in `tableCreationOrder` (the #1006 guard test enforces the pairing).
- `capabilityTokenFrom` is reused to lift a `followers`-only post's token from its stored image URLs for the retro pass.
- Docs: enrichment + retro-enrichment sections in docs/features/feed.md updated.

## Tests
- timeline-enrich: local-origin shortcut (no discovery/HTTP, trailing-slash origin), different-origin still HTTP, discovery/malformed failures now propagate (for logging), 404-style body → null.
- timeline-retro-enrich (new): stores payloads, stamps failed attempts, lifts tokens, skips-and-stamps false SQL-prefilter matches, respects batch size.
- DB integration: `listUnenrichedAurbodaEntries` candidacy matrix + `setTimelineEntryStructured` stamping and never-wipe-with-null.
- Whole-package `pnpm check` green; activitypub/mcp/feed suites + timeline integration pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo