### PR TITLE
feat(feed): keyset-paginate the owner feed listing (#1012)

### DIFF
--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -137,8 +137,21 @@ describe('Feed posts integration', () => {
     const user = getTestUser()
     const first = await createFeedPost(user, postInput())
     const second = await createFeedPost(user, postInput())
-    const posts = await listFeedPosts(user)
+    const posts = await listFeedPosts(user, 10)
     expect(posts.map((p) => p.id)).toEqual([second.id, first.id])
+  })
+
+  test('keyset-paginates by (created_at, id) (#1012)', async () => {
+    const user = getTestUser()
+    const ids: string[] = []
+    for (let i = 0; i < 3; i++) ids.push((await createFeedPost(user, postInput())).id)
+
+    const page1 = await listFeedPosts(user, 2)
+    expect(page1.map((p) => p.id)).toEqual([ids[2], ids[1]])
+
+    const last = page1[page1.length - 1]!
+    const page2 = await listFeedPosts(user, 2, { created_at: last.created_at, id: last.id })
+    expect(page2.map((p) => p.id)).toEqual([ids[0]])
   })
 
   test('updates selected fields and leaves others intact', async () => {
@@ -275,7 +288,7 @@ describe('Feed posts integration', () => {
     test('appears in the owner feed and the public outbox listings', async () => {
       const user = getTestUser()
       const article = await createArticlePost(user, articleInput({ visibility: 'public' }))
-      expect((await listFeedPosts(user)).map((p) => p.id)).toContain(article.id)
+      expect((await listFeedPosts(user, 10)).map((p) => p.id)).toContain(article.id)
       const publicPosts = await listPublicFeedPosts(user)
       expect(publicPosts.map((p) => p.id)).toContain(article.id)
       expect(publicPosts.find((p) => p.id === article.id)?.article?.title).toBe('A week of sleep and HRV')

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -121,12 +121,30 @@ export const createArticlePost = async (user: string, input: ArticlePostInput): 
   return mapFeedPost(result.rows[0])
 }
 
-export const listFeedPosts = async (user: string): Promise<FeedPostRecord[]> => {
+/** Keyset position in the owner's feed: the previous page's last `(created_at, id)`. */
+export interface FeedPostCursor {
+  created_at: Date
+  id: string
+}
+
+/**
+ * A keyset page of the owner's feed posts, newest-first (#1012). The `id`
+ * tiebreaker keeps ordering deterministic when two posts share a `created_at`
+ * (microsecond collision on rapid inserts); pass the previous page's last
+ * `(created_at, id)` as `before` for the next page.
+ */
+export const listFeedPosts = async (
+  user: string,
+  limit: number,
+  before?: FeedPostCursor,
+): Promise<FeedPostRecord[]> => {
   const result = await query<FeedPostRow>(
     user,
-    // `id` tiebreaker keeps ordering deterministic when two posts share a
-    // `created_at` (microsecond collision on rapid inserts).
-    `SELECT ${FEED_POST_COLUMNS} FROM feed_posts ORDER BY created_at DESC, id DESC`,
+    `SELECT ${FEED_POST_COLUMNS} FROM feed_posts
+     WHERE ($1::timestamptz IS NULL OR (created_at, id) < ($1::timestamptz, $2::uuid))
+     ORDER BY created_at DESC, id DESC
+     LIMIT $3`,
+    [before?.created_at ?? null, before?.id ?? null, limit],
   )
   return result.rows.map(mapFeedPost)
 }

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -328,6 +328,7 @@ export {
   createArticlePost,
   createFeedPost,
   deleteFeedPost,
+  type FeedPostCursor,
   type FeedPostInput,
   type FeedPostPatch,
   type FeedPostRecord,

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -5,6 +5,7 @@
  */
 import {
   createArticleBodySchema,
+  feedPostsQuerySchema,
   followActorBodySchema,
   followersQuerySchema,
   shareActivityBodySchema,
@@ -28,14 +29,13 @@ import {
   getFeedPostById,
   listFeedFollowers,
   listFeedFollowing,
-  listFeedPosts,
   updateFeedFollowingNotify,
   updateFeedPost,
 } from '../db/index.ts'
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
-import { normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
+import { getFeedPage, normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
 import { serializeFollower } from '../services/followers.ts'
 import { serializeFollowing } from '../services/following.ts'
 import { getSettings } from '../services/settings.ts'
@@ -62,14 +62,11 @@ export const registerFeedTools = (server: McpServer, user: string, options: Feed
   const { apiBaseUrl, deliver, followActions, followerActions, retroEnrichTimeline } = options
   server.tool(
     'list_feed',
-    'List activities you have published to your feed, with their shared metric selection, series opt-in, and visibility.',
-    {},
-    async () => {
-      const records = await listFeedPosts(user)
+    "List posts you have published to your feed, newest first, with their shared metric selection, series opt-in, and visibility. Pass `cursor` (from a previous call's `next_cursor`) to page.",
+    { ...feedPostsQuerySchema.shape },
+    async ({ cursor, limit }) => {
       const settings = await getSettings(user).catch(() => null)
-      return jsonResponse(
-        await Promise.all(records.map((record) => serializeFeedPost(user, record, { settings }))),
-      )
+      return jsonResponse(await getFeedPage(user, limit, cursor, { settings }))
     },
   )
 

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -14,6 +14,8 @@ import {
   type CreateArticleBody,
   createArticleBodySchema,
   type FeedPostResponse,
+  type FeedPostsQuery,
+  feedPostsQuerySchema,
   type FeedPostsResponse,
   type ShareActivityBody,
   shareActivityBodySchema,
@@ -36,13 +38,12 @@ import {
   deleteFeedPost,
   getActivityById,
   getFeedPostById,
-  listFeedPosts,
   updateFeedPost,
 } from '../db/index.ts'
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
-import { normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
+import { getFeedPage, normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
 import { getSettings } from '../services/settings.ts'
 import { getTimelinePage } from '../services/timeline.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
@@ -80,15 +81,20 @@ export const createFeedRouter = (
 ): TypedRouter => {
   const router = typedRouter()
 
-  router.get<Record<string, never>, FeedPostsResponse>('/', authMiddleware, async (req, res) => {
-    const user = req.user!
-    const records = await listFeedPosts(user)
-    const settings = await getSettings(user).catch(() => null)
-    const posts = await Promise.all(
-      records.map((record) => serializeFeedPost(user, record, { includeStructured: true, settings })),
-    )
-    res.json({ posts, success: true })
-  })
+  router.get<Record<string, never>, FeedPostsResponse, unknown, FeedPostsQuery>(
+    '/',
+    authMiddleware,
+    validateQuery(feedPostsQuerySchema),
+    async (req, res) => {
+      const user = req.user!
+      const settings = await getSettings(user).catch(() => null)
+      const { next_cursor, posts } = await getFeedPage(user, req.query.limit, req.query.cursor, {
+        includeStructured: true,
+        settings,
+      })
+      res.json({ next_cursor, posts, success: true })
+    },
+  )
 
   // Live home-timeline updates over Server-Sent Events. Each ping (`event: new`)
   // means "a new post arrived — refetch the newest page"; the payload is empty so

--- a/apps/backend/src/services/feed.integration.test.ts
+++ b/apps/backend/src/services/feed.integration.test.ts
@@ -12,7 +12,7 @@ import { insertLocations } from '../db/locations.ts'
 import { insertTimeSeries } from '../db/time-series.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
 import { resolveStructuredContent } from './feed-structured.ts'
-import { expandFeedActivityWindow, resolveFeedActivity, serializeFeedPost } from './feed.ts'
+import { expandFeedActivityWindow, getFeedPage, resolveFeedActivity, serializeFeedPost } from './feed.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 
@@ -241,6 +241,40 @@ describe('feed service', () => {
       expect(dto.activity_id).toBe(anchorId)
       expect(dto.activity_title).toBeUndefined()
       expect(dto.activity_start_time).toBeUndefined()
+    })
+  })
+
+  describe('getFeedPage', () => {
+    test('pages newest-first with an opaque cursor; null on the last page (#1012)', async () => {
+      const user = getTestUser()
+      const ids: string[] = []
+      for (let i = 0; i < 3; i++) ids.push((await createFeedPost(user, postInput(null))).id)
+
+      const page1 = await getFeedPage(user, 2, undefined)
+      expect(page1.posts.map((p) => p.id)).toEqual([ids[2], ids[1]])
+      expect(page1.next_cursor).not.toBeNull()
+
+      const page2 = await getFeedPage(user, 2, page1.next_cursor ?? undefined)
+      expect(page2.posts.map((p) => p.id)).toEqual([ids[0]])
+      expect(page2.next_cursor).toBeNull()
+    })
+
+    test('an exactly-full page ends with a cursor whose next page is empty and final', async () => {
+      const user = getTestUser()
+      await createFeedPost(user, postInput(null))
+      await createFeedPost(user, postInput(null))
+
+      const page1 = await getFeedPage(user, 2, undefined)
+      expect(page1.posts).toHaveLength(2)
+      // 2 rows for limit 2: no extra row was fetched, so no next page.
+      expect(page1.next_cursor).toBeNull()
+    })
+
+    test('a malformed cursor falls back to the first page (never a 500)', async () => {
+      const user = getTestUser()
+      const post = await createFeedPost(user, postInput(null))
+      const page = await getFeedPage(user, 10, 'garbage-cursor')
+      expect(page.posts.map((p) => p.id)).toEqual([post.id])
     })
   })
 })

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -19,9 +19,9 @@
  */
 import type { FeedPost } from '@aurboda/api-spec'
 
-import type { Activity, FeedPostRecord } from '../db/index.ts'
+import type { Activity, FeedPostCursor, FeedPostRecord } from '../db/index.ts'
 
-import { getActivityById } from '../db/index.ts'
+import { getActivityById, listFeedPosts } from '../db/index.ts'
 import { resolveActivityScalars } from './activitypub/feed-activity.ts'
 import { feedPostContent, formatActivityWindow } from './activitypub/object.ts'
 import {
@@ -29,6 +29,7 @@ import {
   resolveStructuredRoute,
   resolveStructuredSeries,
 } from './feed-structured-activity.ts'
+import { decodeKeysetCursor, encodeKeysetCursor } from './keyset-cursor.ts'
 import { resolveActivityWindow } from './queries/index.ts'
 import { getSettings } from './settings.ts'
 
@@ -196,5 +197,39 @@ export const serializeFeedPost = async (
     structured,
     updated_at: record.updated_at.toISOString(),
     visibility: record.visibility,
+  }
+}
+
+/** Fetch a keyset page of raw feed-post rows — the one DB dependency of `getFeedPage`. */
+export type FeedPostsFetcher = (
+  user: string,
+  limit: number,
+  before?: FeedPostCursor,
+) => Promise<FeedPostRecord[]>
+
+/**
+ * One keyset page of the owner's feed (newest first) plus the cursor for the
+ * next page — null when there are no more (#1012). Shared by the REST `GET
+ * /feed` route and the MCP `list_feed` tool (parity), like `getTimelinePage`
+ * for the home timeline: fetch `limit + 1` rows to detect a next page without a
+ * second query, serialise the page, and encode the last row's `(created_at,
+ * id)` as the opaque cursor. The row fetcher is injected (defaulting to the
+ * real DB query) so the pagination logic is unit-testable without a database.
+ */
+export const getFeedPage = async (
+  user: string,
+  limit: number,
+  cursor: string | undefined,
+  opts: SerializeFeedPostOpts = {},
+  fetchPosts: FeedPostsFetcher = listFeedPosts,
+): Promise<{ posts: FeedPost[]; next_cursor: string | null }> => {
+  const decoded = decodeKeysetCursor(cursor)
+  const rows = await fetchPosts(user, limit + 1, decoded && { created_at: decoded.ts, id: decoded.id })
+  const hasMore = rows.length > limit
+  const page = hasMore ? rows.slice(0, limit) : rows
+  const last = page[page.length - 1]
+  return {
+    next_cursor: hasMore && last ? encodeKeysetCursor(last.created_at, last.id) : null,
+    posts: await Promise.all(page.map((record) => serializeFeedPost(user, record, opts))),
   }
 }

--- a/apps/backend/src/services/keyset-cursor.test.ts
+++ b/apps/backend/src/services/keyset-cursor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+
+import { decodeKeysetCursor, encodeKeysetCursor } from './keyset-cursor.ts'
+
+const UUID = '11111111-2222-4333-8444-555555555555'
+
+describe('keyset cursor', () => {
+  test('round-trips a (timestamp, id) position', () => {
+    const ts = new Date('2026-07-01T08:00:00.123Z')
+    const decoded = decodeKeysetCursor(encodeKeysetCursor(ts, UUID))
+    expect(decoded).toEqual({ id: UUID, ts })
+  })
+
+  test('missing/empty cursor decodes to undefined (first page)', () => {
+    expect(decodeKeysetCursor(undefined)).toBeUndefined()
+    expect(decodeKeysetCursor('')).toBeUndefined()
+  })
+
+  test('malformed cursors decode to undefined instead of reaching the SQL layer', () => {
+    expect(decodeKeysetCursor('not base64url!')).toBeUndefined()
+    // Valid base64url but no separator / non-UUID id / non-numeric timestamp.
+    expect(decodeKeysetCursor(Buffer.from('justonepart').toString('base64url'))).toBeUndefined()
+    expect(decodeKeysetCursor(Buffer.from('12345:not-a-uuid').toString('base64url'))).toBeUndefined()
+    expect(decodeKeysetCursor(Buffer.from(`NaN:${UUID}`).toString('base64url'))).toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/keyset-cursor.ts
+++ b/apps/backend/src/services/keyset-cursor.ts
@@ -1,0 +1,32 @@
+/**
+ * Opaque keyset-pagination cursor shared by the paginated feed surfaces (the
+ * home timeline on `(published_at, id)`, the owner's feed on `(created_at,
+ * id)`): a `(timestamp, uuid)` position encoded as one base64url token, so
+ * clients treat it as opaque and a crafted value can't reach the SQL layer.
+ */
+
+export interface KeysetCursor {
+  ts: Date
+  id: string
+}
+
+/** Encode a `(timestamp, id)` keyset position as an opaque base64url cursor. */
+export const encodeKeysetCursor = (ts: Date, id: string): string =>
+  Buffer.from(`${ts.getTime()}:${id}`).toString('base64url')
+
+/** A canonical UUID, to validate a decoded cursor's id before it hits a `$::uuid` cast. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Decode an opaque cursor, or undefined if it's missing/malformed (→ first page). */
+export const decodeKeysetCursor = (cursor: string | undefined): KeysetCursor | undefined => {
+  if (cursor == null || cursor === '') return undefined
+  const decoded = Buffer.from(cursor, 'base64url').toString('utf8')
+  const sep = decoded.indexOf(':')
+  if (sep <= 0) return undefined
+  const ms = Number(decoded.slice(0, sep))
+  const id = decoded.slice(sep + 1)
+  // Validate the id is a UUID: it's cast to `uuid` in the page queries, so a
+  // crafted `12345:not-a-uuid` cursor would otherwise 500 instead of paging.
+  if (!Number.isSafeInteger(ms) || !UUID_RE.test(id)) return undefined
+  return { id, ts: new Date(ms) }
+}

--- a/apps/backend/src/services/timeline.ts
+++ b/apps/backend/src/services/timeline.ts
@@ -12,26 +12,12 @@ import type { TimelineEntry } from '@aurboda/api-spec'
 import type { TimelineCursor, TimelineEntryRecord } from '../db/index.ts'
 
 import { listTimelineEntries } from '../db/index.ts'
-
-/** Encode a `(published_at, id)` keyset position as an opaque base64 cursor. */
-const encodeCursor = (record: TimelineEntryRecord): string =>
-  Buffer.from(`${record.published_at.getTime()}:${record.id}`).toString('base64url')
-
-/** A canonical UUID, to validate a decoded cursor's id before it hits the `$::uuid` cast. */
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+import { decodeKeysetCursor, encodeKeysetCursor } from './keyset-cursor.ts'
 
 /** Decode an opaque cursor, or undefined if it's missing/malformed (→ first page). */
 const decodeCursor = (cursor: string | undefined): TimelineCursor | undefined => {
-  if (cursor == null || cursor === '') return undefined
-  const decoded = Buffer.from(cursor, 'base64url').toString('utf8')
-  const sep = decoded.indexOf(':')
-  if (sep <= 0) return undefined
-  const ms = Number(decoded.slice(0, sep))
-  const id = decoded.slice(sep + 1)
-  // Validate the id is a UUID: it's cast to `uuid` in listTimelineEntries, so a
-  // crafted `12345:not-a-uuid` cursor would otherwise 500 instead of paging.
-  if (!Number.isSafeInteger(ms) || !UUID_RE.test(id)) return undefined
-  return { id, published_at: new Date(ms) }
+  const decoded = decodeKeysetCursor(cursor)
+  return decoded && { id: decoded.id, published_at: decoded.ts }
 }
 
 export const serializeTimelineEntry = (record: TimelineEntryRecord): TimelineEntry => ({
@@ -73,6 +59,6 @@ export const getTimelinePage = async (
   const last = page[page.length - 1]
   return {
     entries: page.map(serializeTimelineEntry),
-    next_cursor: hasMore && last ? encodeCursor(last) : null,
+    next_cursor: hasMore && last ? encodeKeysetCursor(last.published_at, last.id) : null,
   }
 }

--- a/apps/web/src/pages/Feed/index.tsx
+++ b/apps/web/src/pages/Feed/index.tsx
@@ -4,9 +4,10 @@
  * actually appear once federated), each with an Edit / Unshare shortcut. Editing
  * reuses the share dialog; unsharing retracts a Delete to followers.
  */
-import type { FeedPost } from '@aurboda/api-spec'
+import type { FeedPost, FeedPostsResponse } from '@aurboda/api-spec'
+import type { InfiniteData } from '@tanstack/react-query'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'preact/hooks'
 
 import { ArticleEditorDialog } from '../../components/ArticleEditorDialog'
@@ -81,7 +82,21 @@ function OwnPostCard({ post, author }: { post: FeedPost; author: PostAuthor }) {
 }
 
 export function Feed() {
-  const { data: posts, isLoading, error } = useQuery({ queryFn: fetchFeed, queryKey: ['feed'] })
+  // Keyset-paginated like the home timeline (#1012): each page carries the full
+  // structured payloads, so the first load stays light however many posts exist.
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery<
+    FeedPostsResponse,
+    Error,
+    InfiniteData<FeedPostsResponse>,
+    readonly string[],
+    string | undefined
+  >({
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) => fetchFeed(pageParam),
+    queryKey: ['feed', 'posts'],
+  })
+  const posts = data?.pages.flatMap((page) => page.posts)
   const [composing, setComposing] = useState(false)
 
   const username = auth.value.user ?? ''
@@ -127,6 +142,16 @@ export function Feed() {
       {posts?.map((post) => (
         <OwnPostCard key={post.id} post={post} author={author} />
       ))}
+      {hasNextPage && (
+        <button
+          type="button"
+          class="btn-secondary timeline-more"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? 'Loading…' : 'Load more'}
+        </button>
+      )}
     </div>
   )
 }

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -36,10 +36,16 @@ export const shareActivity = async (activityId: string, body: ShareActivityBody)
   return response.data.post
 }
 
-/** List every post the user has shared to their feed, newest-first. */
-export const fetchFeed = async (): Promise<FeedPost[]> => {
-  const response = await axios.get<FeedPostsResponse>(`${API_URL}/feed`, { headers: authHeaders() })
-  return response.data.posts
+/**
+ * One keyset page of the user's own feed posts, newest-first (#1012). Pass the
+ * previous page's `next_cursor` for the next page; null means the last page.
+ */
+export const fetchFeed = async (cursor?: string): Promise<FeedPostsResponse> => {
+  const response = await axios.get<FeedPostsResponse>(`${API_URL}/feed`, {
+    headers: authHeaders(),
+    params: cursor === undefined ? {} : { cursor },
+  })
+  return response.data
 }
 
 /** Update a shared post's metric selection, series opt-in, or visibility. */

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -490,7 +490,9 @@ resolving.
   feed responses include the full structured payload (typed scalars + inline series + route,
   assembled by the same helper the public structured endpoint uses), so the author sees the
   interactive combined chart and time-synced map exactly as a follower would, and can verify
-  what they shared. The public profile renders the lighter native **stat grid** (message +
+  what they shared. The listing is **keyset-paginated** (20 per page, "Load more" — the same
+  cursor style as the home timeline), so the inline payload weight stays bounded per request
+  however many posts exist (#1012). The public profile renders the lighter native **stat grid** (message +
   activity date + typed scalars) without the series weight — and the MCP `list_feed` tool
   likewise omits `structured` (an intentional payload-weight divergence from `GET /feed`,
   not a capability gap: the underlying data is all reachable via the metric-query tools).
@@ -532,7 +534,7 @@ Owner-facing (authenticated, scoped to the caller):
 
 | Method & path                      | Purpose                                                                                                                 |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `GET /feed`                        | List my feed posts (each enriched with the shared activity's title/type and merged-span window, resolved at query time) |
+| `GET /feed`                        | My feed posts, newest-first, keyset-paginated (`?cursor=` from the previous page's `next_cursor`); each post enriched with the shared activity's title/type, merged-span window, and full structured payload |
 | `POST /feed/activities/:id/share`  | Publish an activity with a chosen metric selection                                                                      |
 | `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart/correlation blocks)                                       |
 | `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                          |

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -320,9 +320,36 @@ export const feedPostResponseSchema = baseResponseSchema
 
 export type FeedPostResponse = z.infer<typeof feedPostResponseSchema>
 
-/** Response wrapping the owner's list of feed posts. */
+/** Query for the owner's feed listing (keyset pagination, like the home timeline). */
+export const feedPostsQuerySchema = z
+  .object({
+    cursor: z.string().optional().meta({ description: "Opaque cursor from a previous page's `next_cursor`" }),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(20)
+      .meta({ description: 'Max posts to return (1–50, default 20)' }),
+  })
+  .meta({ id: 'FeedPostsQuery' })
+
+export type FeedPostsQuery = z.infer<typeof feedPostsQuerySchema>
+
+/**
+ * Response wrapping a list of feed posts. The owner's `GET /feed` pages with
+ * `next_cursor` (null on the last page); the bounded public-profile listing
+ * omits it.
+ */
 export const feedPostsResponseSchema = baseResponseSchema
-  .extend({ posts: z.array(feedPostSchema) })
+  .extend({
+    next_cursor: z
+      .string()
+      .nullable()
+      .optional()
+      .meta({ description: 'Cursor for the next page; null on the last page; absent when unpaginated' }),
+    posts: z.array(feedPostSchema),
+  })
   .meta({ id: 'FeedPostsResponse' })
 
 export type FeedPostsResponse = z.infer<typeof feedPostsResponseSchema>


### PR DESCRIPTION
Closes #1012

`GET /feed` was unpaginated while (since #1009/#1013) every activity post inlines its full structured payload — 5s-bucketed series (~90KB/metric/post for a 1h activity) plus, per `include_map` post, the downsampled GPS route and a raw-locations query. The listing therefore grew linearly with feed size, in payload and in per-post DB work. It is now **keyset-paginated on `(created_at, id)`** — the same cursor style as the home timeline — 20 posts per page, so the first load stays light however many posts exist.

## Design
- **Why not the issue's lazy-fetch alternative:** having cards fetch `structured` from the cached per-post public endpoint would break parity for the owner's **`followers`-only** posts — that endpoint requires the capability token, which the owner's browser deliberately never has (#893). Pagination keeps the owner's WYSIWYG card for every visibility.
- **api-spec:** new `FeedPostsQuery` (`cursor`, `limit` 1–50 default 20); `FeedPostsResponse` gains an optional nullable `next_cursor` — the bounded public-profile listing keeps omitting it, and existing clients reading `posts` are unaffected.
- **Shared cursor codec:** the timeline's opaque `(timestamp, uuid)` base64url cursor moved to `services/keyset-cursor.ts` (UUID-validated before any `::uuid` cast; malformed → first page, never a 500). `timeline.ts` refactored onto it, behavior unchanged.
- **Backend:** `listFeedPosts(user, limit, before?)` keyset page (id tiebreaker as before); `getFeedPage` in `services/feed.ts` (fetch `limit+1`, injectable fetcher) shared by REST `GET /feed` and MCP `list_feed` — both surfaces page identically (parity).
- **Web:** the Feed page's own posts use `useInfiniteQuery` + **Load more**, mirroring the home timeline; the query key becomes `['feed','posts']`, still matched by all existing `['feed']` invalidations (share/edit/unshare dialogs).

## Tests
- `keyset-cursor` unit tests: round-trip, empty, malformed (no separator, non-UUID id, non-numeric timestamp).
- `getFeedPage` integration: 3-post paging with cursor, exactly-full page ends with `next_cursor: null`, malformed cursor falls back to page 1.
- DB integration: `listFeedPosts` keyset paging.
- Whole-monorepo `pnpm check` green; feed/mcp/router integration suites + all 581 web tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo