### PR TITLE
fix(web): always precheck Distance + Calories in the share dialog

### DIFF
--- a/apps/web/src/components/feed-metrics.test.ts
+++ b/apps/web/src/components/feed-metrics.test.ts
@@ -20,20 +20,29 @@ describe('defaultsFromChart', () => {
 
   it('maps charted metrics to their summaries (HR → avg + max + zones) and full series', () => {
     const { summary, series } = defaultsFromChart(['heart_rate', 'distance'])
-    expect(summary).toEqual(['duration', 'distance', 'heart_rate_avg', 'heart_rate_max', 'hr_zone_minutes'])
+    expect(summary).toEqual([
+      'duration',
+      'distance',
+      'calories',
+      'heart_rate_avg',
+      'heart_rate_max',
+      'hr_zone_minutes',
+    ])
     expect(series).toEqual(['heart_rate'])
   })
 
-  it('includes series for a charted metric with no scalar summary (e.g. speed)', () => {
+  it('always prechecks the cumulative staples the chart cannot mirror (distance, calories)', () => {
+    // Distance/calories are excluded from the chart by design, so chart
+    // mirroring alone would never precheck them — a run without Distance reads
+    // wrong. The dialog drops them again for activities without the data.
     const { summary, series } = defaultsFromChart(['speed'])
-    // speed has no summary source; duration is always included.
-    expect(summary).toEqual(['duration'])
+    expect(summary).toEqual(['duration', 'distance', 'calories'])
     expect(series).toEqual(['speed'])
   })
 
   it('ignores charted metrics the dialog cannot represent', () => {
     const { summary, series } = defaultsFromChart(['hrv_rmssd'])
-    expect(summary).toEqual(['duration'])
+    expect(summary).toEqual(['duration', 'distance', 'calories'])
     expect(series).toEqual([])
   })
 })

--- a/apps/web/src/components/feed-metrics.ts
+++ b/apps/web/src/components/feed-metrics.ts
@@ -35,18 +35,34 @@ export const SERIES_METRICS: { key: MetricType; label: string }[] = [
 export const DEFAULT_SUMMARY = ['duration', 'distance', 'heart_rate_avg', 'heart_rate_max', 'calories']
 
 /**
+ * Summaries whose source is cumulative and therefore NEVER drawn on the
+ * activity chart (`EXCLUDED_METRICS`) — mirroring the chart can't represent the
+ * user's intent about them, yet they're the staple share stats (a run without
+ * Distance reads wrong). Always prechecked; the dialog only offers (and
+ * `buildShareBody` only sends) metrics the activity actually has, so these
+ * silently drop out for activities without the data.
+ */
+const CUMULATIVE_STAPLES = ['distance', 'calories']
+
+/**
  * Seed the share dialog's initial selection from the metrics currently shown on
- * the activity's chart: `duration` (always) plus every summary whose source
- * metric is on the chart, and the full series for each charted metric. Falls
- * back to {@link DEFAULT_SUMMARY} (no series) when the chart selection is unknown.
+ * the activity's chart: `duration` and the cumulative staples (always) plus
+ * every summary whose source metric is on the chart, and the full series for
+ * each charted metric. Falls back to {@link DEFAULT_SUMMARY} (no series) when
+ * the chart selection is unknown.
  */
 export const defaultsFromChart = (chartMetrics?: string[]): { summary: string[]; series: MetricType[] } => {
   if (!chartMetrics || chartMetrics.length === 0) return { series: [], summary: DEFAULT_SUMMARY }
   return {
     series: SERIES_METRICS.filter((m) => chartMetrics.includes(m.key)).map((m) => m.key),
+    // The staples are excluded from the mirror pass so a charted `distance`
+    // (possible via a custom chart selection) isn't prechecked twice.
     summary: [
       'duration',
-      ...SUMMARY_METRICS.filter((m) => m.source && chartMetrics.includes(m.source)).map((m) => m.key),
+      ...CUMULATIVE_STAPLES,
+      ...SUMMARY_METRICS.filter(
+        (m) => m.source && chartMetrics.includes(m.source) && !CUMULATIVE_STAPLES.includes(m.key),
+      ).map((m) => m.key),
     ],
   }
 }


### PR DESCRIPTION
Fredrik's feedback on the live feed: Distance is missing from the summary numbers on his running/walking/canoeing/rowing shares. Checking the public posts confirms `distance` was never in `included_metrics` on any of them.

**Root cause:** the share dialog's default selection mirrors the metrics shown on the activity chart (`defaultsFromChart`), but `distance` and `calories_active` are cumulative and deliberately excluded from the chart (`EXCLUDED_METRICS`) — so chart-mirroring can never precheck Distance or Calories, the two most staple share stats. (His posts have Calories only because he re-checked it by hand each time.)

**Fix:** `defaultsFromChart` now always includes the cumulative staples `distance` + `calories` alongside `duration`, before the chart-mirrored summaries (deduped in case a custom chart charts distance). Availability filtering is unchanged: the dialog only offers — and `buildShareBody` only sends — metrics the activity actually has data for, so a yoga session still gets no Distance checkbox.

Existing posts aren't rewritten; each can gain Distance by opening **Edit** on the post and ticking it (it's offered, just wasn't prechecked).

Tests updated + a new case pinning the staple behavior; web `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo