### PR TITLE
feat(feed): share a challenge to the federated feed (#994 phase 1)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -63,10 +63,13 @@ import { createOAuthRouter } from './routes/oauth-router.ts'
 import {
   deliverFeedArticlePost,
   deliverFeedArticleUpdate,
+  deliverFeedChallengePost,
+  deliverFeedChallengeUpdate,
   deliverFeedDelete,
   deliverFeedPost,
   deliverFeedUpdate,
   toDeliverableArticle,
+  toDeliverableChallenge,
 } from './services/activitypub/deliver.ts'
 import { createFeedFederation } from './services/activitypub/federation.ts'
 import { createTimelineBackfiller } from './services/activitypub/timeline-backfill.ts'
@@ -416,6 +419,23 @@ const main = async () => {
       const article = toDeliverableArticle(post)
       if (article) {
         void deliverFeedArticleUpdate(feedDeps, user, article).catch(onDeliverError('update', user, post.id))
+      }
+    },
+    // Challenge invitations federate like articles: a self-contained Note (#994).
+    createdChallenge: (user, post) => {
+      const challenge = toDeliverableChallenge(post)
+      if (challenge) {
+        void deliverFeedChallengePost(feedDeps, user, challenge).catch(
+          onDeliverError('create', user, post.id),
+        )
+      }
+    },
+    updatedChallenge: (user, post) => {
+      const challenge = toDeliverableChallenge(post)
+      if (challenge) {
+        void deliverFeedChallengeUpdate(feedDeps, user, challenge).catch(
+          onDeliverError('update', user, post.id),
+        )
       }
     },
   }

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -167,7 +167,7 @@ export const mountRestRouters = ({
   httpd.use('/feed/followers', createFeedFollowersRouter(authMiddleware, followerActions))
   httpd.use(
     '/feed',
-    createFeedRouter(authMiddleware, feedDeliver, timelineHub, apiBaseUrl, retroEnrichTimeline),
+    createFeedRouter(authMiddleware, feedDeliver, timelineHub, apiBaseUrl, retroEnrichTimeline, webHost),
   )
   httpd.use('/challenges', createChallengesRouter(authMiddleware, webHost, apiBaseUrl))
   httpd.use(createChallengeDataRouter())

--- a/apps/backend/src/db/challenges.ts
+++ b/apps/backend/src/db/challenges.ts
@@ -472,6 +472,18 @@ export const listChallengeParticipations = async (user: string): Promise<Challen
   return result.rows.map(mapParticipation)
 }
 
+export const getParticipationById = async (
+  user: string,
+  id: string,
+): Promise<ChallengeParticipationRecord | null> => {
+  const result = await query<ParticipationRow>(
+    user,
+    `SELECT ${PARTICIPATION_COLUMNS} FROM challenge_participations WHERE id = $1`,
+    [id],
+  )
+  return result.rows.length ? mapParticipation(result.rows[0]) : null
+}
+
 export const getParticipationByToken = async (
   user: string,
   token: string,

--- a/apps/backend/src/db/feed.integration.test.ts
+++ b/apps/backend/src/db/feed.integration.test.ts
@@ -10,6 +10,7 @@ import {
   type ArticlePostInput,
   countPublicFeedPosts,
   createArticlePost,
+  createChallengePost,
   createFeedPost,
   deleteFeedPost,
   type FeedPostInput,
@@ -369,6 +370,28 @@ describe('Feed posts integration', () => {
       await createFeedPost(user, postInput({ activity_id: activityId, series_metrics: ['heart_rate'] }))
       await deleteActivity(user, activityId)
       expect(await findCoveringSharedSeriesWindow(user, 'heart_rate', within.start, within.end)).toBeNull()
+    })
+  })
+
+  describe('challenge posts (#994)', () => {
+    test('createChallengePost stores the payload + note and lists like any post', async () => {
+      const user = getTestUser()
+      const post = await createChallengePost(user, {
+        challenge: { name: 'August 10k', url: 'https://aurboda.example/u/me/aug10k' },
+        message: 'Join me!',
+        visibility: 'unlisted',
+      })
+      expect(post.kind).toBe('challenge')
+      expect(post.challenge).toEqual({ name: 'August 10k', url: 'https://aurboda.example/u/me/aug10k' })
+      expect(post.message).toBe('Join me!')
+      expect(post.activity_id).toBeNull()
+      expect(post.article).toBeNull()
+
+      const fetched = await getFeedPostById(user, post.id)
+      expect(fetched?.challenge).toEqual(post.challenge)
+      expect((await listFeedPosts(user, 10)).map((p) => p.id)).toContain(post.id)
+      // Public/unlisted challenge shares appear on the outbox listing like any post.
+      expect((await listPublicFeedPosts(user)).map((p) => p.id)).toContain(post.id)
     })
   })
 })

--- a/apps/backend/src/db/feed.ts
+++ b/apps/backend/src/db/feed.ts
@@ -1,4 +1,4 @@
-import type { ArticleContent, FeedPostKind, FeedVisibility } from '@aurboda/api-spec'
+import type { ArticleContent, ChallengeShare, FeedPostKind, FeedVisibility } from '@aurboda/api-spec'
 
 /**
  * Feed posts — activities a user published to their federated feed.
@@ -26,6 +26,8 @@ export interface FeedPostRecord {
   include_chart: boolean
   /** Stored article payload (title + default window + blocks); null for `activity` posts. */
   article: ArticleContent | null
+  /** Stored challenge link payload (name + canonical URL); null unless kind = 'challenge'. */
+  challenge: ChallengeShare | null
   /** The author's personal message (plain text), or null when none was shared. */
   message: string | null
   /** Unguessable capability token for `followers`-only image URLs (see schema). */
@@ -51,6 +53,13 @@ export interface ArticlePostInput {
   article: ArticleContent
 }
 
+export interface ChallengePostInput {
+  visibility: FeedVisibility
+  challenge: ChallengeShare
+  /** The author's personal note (markdown); omitted/undefined stores NULL. */
+  message?: string | null
+}
+
 export interface FeedPostPatch {
   included_metrics?: string[]
   series_metrics?: string[]
@@ -64,7 +73,7 @@ export interface FeedPostPatch {
 }
 
 const FEED_POST_COLUMNS =
-  'id, kind, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, article, message, image_token, created_at, updated_at'
+  'id, kind, activity_id, included_metrics, series_metrics, visibility, include_map, include_chart, article, challenge, message, image_token, created_at, updated_at'
 
 interface FeedPostRow {
   id: string
@@ -77,6 +86,7 @@ interface FeedPostRow {
   include_chart: boolean
   // pg parses a jsonb column to its JS value on read (null for `activity` posts).
   article: ArticleContent | null
+  challenge: ChallengeShare | null
   message: string | null
   image_token: string
   created_at: Date
@@ -117,6 +127,25 @@ export const createArticlePost = async (user: string, input: ArticlePostInput): 
      VALUES ('article', $1, $2)
      RETURNING ${FEED_POST_COLUMNS}`,
     [input.visibility, JSON.stringify(input.article)],
+  )
+  return mapFeedPost(result.rows[0])
+}
+
+/**
+ * Create a `challenge` post (#994): the resolved challenge link payload in the
+ * `challenge` JSONB plus the author's personal note. No activity anchor and no
+ * shared metrics — the post is an invitation, not a data share.
+ */
+export const createChallengePost = async (
+  user: string,
+  input: ChallengePostInput,
+): Promise<FeedPostRecord> => {
+  const result = await query<FeedPostRow>(
+    user,
+    `INSERT INTO feed_posts (kind, visibility, challenge, message)
+     VALUES ('challenge', $1, $2, $3)
+     RETURNING ${FEED_POST_COLUMNS}`,
+    [input.visibility, JSON.stringify(input.challenge), input.message ?? null],
   )
   return mapFeedPost(result.rows[0])
 }

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -257,6 +257,7 @@ export {
   getChallengeById,
   getChallengeBySlug,
   getChallengeMemberByIdentity,
+  getParticipationById,
   getParticipationByToken,
   getParticipationByUrl,
   listChallengeMembers,
@@ -325,7 +326,9 @@ export { emitTimelineNotify, openTimelineChannel } from './timeline-notify.ts'
 export {
   type ArticlePostInput,
   countPublicFeedPosts,
+  type ChallengePostInput,
   createArticlePost,
+  createChallengePost,
   createFeedPost,
   deleteFeedPost,
   type FeedPostCursor,

--- a/apps/backend/src/mcp.ts
+++ b/apps/backend/src/mcp.ts
@@ -107,6 +107,7 @@ const createMcpServer = (user: string, deps: McpDeps = {}): McpServer => {
     followActions: deps.followActions,
     followerActions: deps.followerActions,
     retroEnrichTimeline: deps.retroEnrichTimeline,
+    webHost: deps.webHost,
   })
   registerChallengeTools(server, user, { apiBaseUrl: deps.apiBaseUrl, webHost: deps.webHost })
   registerScreentimeCategoryTools(server, user)

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -111,9 +111,11 @@ export const registerFeedTools = (server: McpServer, user: string, options: Feed
         visibility: body.visibility,
       })
       if (!record) return errorResponse('Feed post not found')
-      // Federate the edit as an Update, same as the REST update route. An article
-      // has no linked activity, so route it through the article path.
+      // Federate the edit as an Update, same as the REST update route. Articles
+      // and challenge shares have no linked activity, so they must go through
+      // their own paths — the generic `updated` would silently no-op.
       if (record.kind === 'article') deliver?.updatedArticle(user, record)
+      else if (record.kind === 'challenge') deliver?.updatedChallenge(user, record)
       else deliver?.updated(user, record)
       return jsonResponse(await serializeFeedPost(user, record))
     },

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -6,6 +6,7 @@
 import {
   createArticleBodySchema,
   feedPostsQuerySchema,
+  shareChallengeBodySchema,
   followActorBodySchema,
   followersQuerySchema,
   shareActivityBodySchema,
@@ -23,6 +24,7 @@ import type { RetroEnrichTrigger } from '../services/timeline-retro-enrich.ts'
 
 import {
   createArticlePost,
+  createChallengePost,
   createFeedPost,
   deleteFeedPost,
   getActivityById,
@@ -35,6 +37,7 @@ import {
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
+import { resolveChallengeShare } from '../services/challenge-share.ts'
 import { getFeedPage, normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
 import { serializeFollower } from '../services/followers.ts'
 import { serializeFollowing } from '../services/following.ts'
@@ -56,10 +59,12 @@ export interface FeedToolsOptions {
   followerActions?: FollowerActions
   apiBaseUrl?: string
   retroEnrichTimeline?: RetroEnrichTrigger
+  /** Canonical web origin, to build a shared challenge's public URL (#994). */
+  webHost?: string
 }
 
 export const registerFeedTools = (server: McpServer, user: string, options: FeedToolsOptions = {}) => {
-  const { apiBaseUrl, deliver, followActions, followerActions, retroEnrichTimeline } = options
+  const { apiBaseUrl, deliver, followActions, followerActions, retroEnrichTimeline, webHost } = options
   server.tool(
     'list_feed',
     "List posts you have published to your feed, newest first, with their shared metric selection, series opt-in, and visibility. Pass `cursor` (from a previous call's `next_cursor`) to page.",
@@ -110,6 +115,23 @@ export const registerFeedTools = (server: McpServer, user: string, options: Feed
       // has no linked activity, so route it through the article path.
       if (record.kind === 'article') deliver?.updatedArticle(user, record)
       else deliver?.updated(user, record)
+      return jsonResponse(await serializeFeedPost(user, record))
+    },
+  )
+
+  server.tool(
+    'share_challenge',
+    "Publish a challenge INVITATION to your feed: your personal note (markdown) plus the challenge's canonical join-by-URL link. Pass exactly one of `challenge_id` (one of your own challenges) or `participation_id` (a challenge you joined, possibly hosted elsewhere) — the server resolves the linked name/URL itself.",
+    { ...shareChallengeBodySchema.shape },
+    async ({ challenge_id, message, participation_id, visibility }) => {
+      const resolved = await resolveChallengeShare(user, { challenge_id, participation_id }, webHost)
+      if (!resolved.ok) return errorResponse(resolved.error)
+      const record = await createChallengePost(user, {
+        challenge: resolved.challenge,
+        message: normalizeFeedMessage(message) ?? null,
+        visibility,
+      })
+      deliver?.createdChallenge(user, record)
       return jsonResponse(await serializeFeedPost(user, record))
     },
   )

--- a/apps/backend/src/routes/feed-image-router.test.ts
+++ b/apps/backend/src/routes/feed-image-router.test.ts
@@ -27,6 +27,7 @@ const activity: ImageActivity = {
 const makePost = (overrides: Partial<FeedPostRecord> = {}): FeedPostRecord => ({
   activity_id: ACTIVITY_ID,
   article: null,
+  challenge: null,
   created_at: new Date('2026-07-01T08:00:00Z'),
   id: POST_ID,
   image_token: 'secret-token',

--- a/apps/backend/src/routes/feed-router.integration.test.ts
+++ b/apps/backend/src/routes/feed-router.integration.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vit
  * spy covers the article fan-out branches (including `kind === 'article'` on the
  * generic `PATCH /:postId`); the actual AS2 delivery is unit-tested in `deliver`.
  */
+import { createChallenge, createChallengeParticipation } from '../db/challenges.ts'
 import { createFeedPost } from '../db/feed.ts'
 import { insertTimeSeries } from '../db/time-series.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
@@ -25,10 +26,10 @@ const auth: RequestHandler = (req, _res, next) => {
   next()
 }
 
-const startApp = (deliver?: FeedDeliver, apiBaseUrl?: string) => {
+const startApp = (deliver?: FeedDeliver, apiBaseUrl?: string, webHost?: string) => {
   const app = express()
   app.use(express.json())
-  app.use('/feed', createFeedRouter(auth, deliver, undefined, apiBaseUrl))
+  app.use('/feed', createFeedRouter(auth, deliver, undefined, apiBaseUrl, undefined, webHost))
   const server = app.listen(0)
   const port = (server.address() as AddressInfo).port
   const close = () =>
@@ -139,7 +140,9 @@ describe('Article feed routes (integration)', () => {
       createdArticle: vi.fn(),
       deleted: vi.fn(),
       updated: vi.fn(),
+      createdChallenge: vi.fn(),
       updatedArticle: vi.fn(),
+      updatedChallenge: vi.fn(),
     }
     const spied = startApp(deliver)
     try {
@@ -237,5 +240,130 @@ describe('GET /feed/articles/:postId/export (Reddit/markdown export, C4)', () =>
     const res = await withBase.request.get(`/feed/articles/${created.body.post.id}/export`)
     expect(res.status).toBe(400)
     expect(res.body.error).toContain('followers-only')
+  })
+})
+
+describe('POST /feed/challenges (share a challenge — #994)', () => {
+  let app: ReturnType<typeof startApp>
+  let deliver: FeedDeliver
+
+  beforeAll(async () => {
+    await startTestDb()
+    deliver = {
+      created: vi.fn(),
+      createdArticle: vi.fn(),
+      createdChallenge: vi.fn(),
+      deleted: vi.fn(),
+      updated: vi.fn(),
+      updatedArticle: vi.fn(),
+      updatedChallenge: vi.fn(),
+    }
+    app = startApp(deliver, undefined, 'https://aurboda.example')
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await app.close()
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+    vi.clearAllMocks()
+  })
+
+  const spec = {
+    activity_type_id: null,
+    aggregation: 'sum' as const,
+    bucket_size: '1d' as const,
+    pattern: 'steps',
+    source_type: 'metric' as const,
+    unit: 'steps',
+  }
+
+  test('shares one of my own challenges: resolves name + canonical share URL server-side', async () => {
+    const user = getTestUser()
+    const challenge = await createChallenge(user, {
+      end_ts: new Date('2026-08-31T00:00:00Z'),
+      is_public: true,
+      name: 'August 10k',
+      spec,
+      start_ts: new Date('2026-08-01T00:00:00Z'),
+      timezone: 'Europe/Stockholm',
+    })
+
+    const res = await app.request
+      .post('/feed/challenges')
+      .send({ challenge_id: challenge.id, message: 'Join me — **daily**!', visibility: 'public' })
+    expect(res.status).toBe(200)
+    expect(res.body.post.kind).toBe('challenge')
+    expect(res.body.post.challenge).toEqual({
+      name: 'August 10k',
+      url: `https://aurboda.example/u/${user}/${challenge.slug}`,
+    })
+    expect(res.body.post.message).toBe('Join me — **daily**!')
+    expect(deliver.createdChallenge).toHaveBeenCalledTimes(1)
+  })
+
+  test('shares a joined (remote) challenge from its stored participation', async () => {
+    const user = getTestUser()
+    const participation = await createChallengeParticipation(user, {
+      challenge_url: 'https://peer.example/u/bob/spring-run',
+      end_ts: new Date('2026-08-31T00:00:00Z'),
+      host_identity: '@bob@peer.example',
+      name: 'Spring run',
+      spec,
+      start_ts: new Date('2026-08-01T00:00:00Z'),
+      timezone: 'UTC',
+    })
+
+    const res = await app.request
+      .post('/feed/challenges')
+      .send({ participation_id: participation.id, visibility: 'followers' })
+    expect(res.status).toBe(200)
+    expect(res.body.post.challenge).toEqual({
+      host_identity: '@bob@peer.example',
+      name: 'Spring run',
+      url: 'https://peer.example/u/bob/spring-run',
+    })
+    expect(res.body.post.visibility).toBe('followers')
+  })
+
+  test('400s unless exactly one of challenge_id/participation_id is given', async () => {
+    const both = await app.request.post('/feed/challenges').send({
+      challenge_id: '11111111-2222-4333-8444-555555555555',
+      participation_id: '11111111-2222-4333-8444-555555555556',
+    })
+    expect(both.status).toBe(400)
+    const neither = await app.request.post('/feed/challenges').send({})
+    expect(neither.status).toBe(400)
+  })
+
+  test('404s for an unknown challenge or participation', async () => {
+    const c = await app.request
+      .post('/feed/challenges')
+      .send({ challenge_id: '11111111-2222-4333-8444-555555555555' })
+    expect(c.status).toBe(404)
+    const p = await app.request
+      .post('/feed/challenges')
+      .send({ participation_id: '11111111-2222-4333-8444-555555555555' })
+    expect(p.status).toBe(404)
+  })
+
+  test('a visibility flip via the generic PATCH federates through the challenge path', async () => {
+    const user = getTestUser()
+    const challenge = await createChallenge(user, {
+      end_ts: new Date('2026-08-31T00:00:00Z'),
+      is_public: true,
+      name: 'August 10k',
+      spec,
+      start_ts: new Date('2026-08-01T00:00:00Z'),
+      timezone: 'UTC',
+    })
+    const created = await app.request.post('/feed/challenges').send({ challenge_id: challenge.id })
+    const patched = await app.request.patch(`/feed/${created.body.post.id}`).send({ visibility: 'unlisted' })
+    expect(patched.status).toBe(200)
+    expect(deliver.updatedChallenge).toHaveBeenCalledTimes(1)
+    expect(deliver.updated).not.toHaveBeenCalled()
+    expect(deliver.updatedArticle).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -19,6 +19,8 @@ import {
   type FeedPostsResponse,
   type ShareActivityBody,
   shareActivityBodySchema,
+  type ShareChallengeBody,
+  shareChallengeBodySchema,
   type TimelineQuery,
   timelineQuerySchema,
   type TimelineResponse,
@@ -34,6 +36,7 @@ import type { RetroEnrichTrigger } from '../services/timeline-retro-enrich.ts'
 
 import {
   createArticlePost,
+  createChallengePost,
   createFeedPost,
   deleteFeedPost,
   getActivityById,
@@ -43,6 +46,7 @@ import {
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
+import { resolveChallengeShare } from '../services/challenge-share.ts'
 import { getFeedPage, normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
 import { getSettings } from '../services/settings.ts'
 import { getTimelinePage } from '../services/timeline.ts'
@@ -70,6 +74,10 @@ export interface FeedDeliver {
   createdArticle: (user: string, post: FeedPostRecord) => void
   /** Federate an article edit as an `Update` so followers replace the stored object. */
   updatedArticle: (user: string, post: FeedPostRecord) => void
+  /** Fan a freshly-shared challenge invitation out to followers (#994). */
+  createdChallenge: (user: string, post: FeedPostRecord) => void
+  /** Federate a challenge-share edit as an `Update`. */
+  updatedChallenge: (user: string, post: FeedPostRecord) => void
 }
 
 export const createFeedRouter = (
@@ -78,6 +86,8 @@ export const createFeedRouter = (
   hub?: TimelineHub,
   apiBaseUrl?: string,
   retroEnrichTimeline?: RetroEnrichTrigger,
+  /** Canonical web origin, to build a shared challenge's public URL (#994). */
+  webHost?: string,
 ): TypedRouter => {
   const router = typedRouter()
 
@@ -179,6 +189,28 @@ export const createFeedRouter = (
       // Fan the post out to followers (best-effort; never blocks the response).
       deliver?.created(user, record, activity)
       res.json({ post: await serializeFeedPost(user, record, { includeStructured: true }), success: true })
+    },
+  )
+
+  // Challenge shares (#994): publish an invitation to one of the user's own
+  // challenges (`challenge_id`) or a challenge they joined (`participation_id`)
+  // — exactly one. The linked name/URL are resolved server-side so a post can
+  // never carry a spoofed link. Registered before the generic `/:postId` routes.
+  router.post<Record<string, never>, FeedPostResponse, ShareChallengeBody>(
+    '/challenges',
+    authMiddleware,
+    validateBody(shareChallengeBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const resolved = await resolveChallengeShare(user, req.body, webHost)
+      if (!resolved.ok) return res.status(resolved.status).json({ error: resolved.error, success: false })
+      const record = await createChallengePost(user, {
+        challenge: resolved.challenge,
+        message: normalizeFeedMessage(req.body.message) ?? null,
+        visibility: req.body.visibility,
+      })
+      deliver?.createdChallenge(user, record)
+      res.json({ post: await serializeFeedPost(user, record), success: true })
     },
   )
 
@@ -293,6 +325,7 @@ export const createFeedRouter = (
       // An article (e.g. a visibility flip via this generic route) has no linked
       // activity, so it must go through the article path — `updated` would no-op.
       if (record.kind === 'article') deliver?.updatedArticle(user, record)
+      else if (record.kind === 'challenge') deliver?.updatedChallenge(user, record)
       else deliver?.updated(user, record)
       res.json({ post: await serializeFeedPost(user, record, { includeStructured: true }), success: true })
     },

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -144,6 +144,7 @@ export const tableCreationOrder = [
   'feed_posts',
   'feed_posts_article_columns',
   'feed_posts_message_column',
+  'feed_posts_challenge_column',
   'feed_posts_indexes',
   'feed_tombstone',
   'feed_actor',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -125,6 +125,8 @@ export const socialTables: Record<string, string> = {
       include_map       BOOLEAN NOT NULL DEFAULT false,
       include_chart     BOOLEAN NOT NULL DEFAULT false,
       article           JSONB,
+      -- Challenge link payload (name + canonical URL) for kind = 'challenge' (#994).
+      challenge         JSONB,
       message           TEXT,
       image_token       TEXT NOT NULL DEFAULT gen_random_uuid()::text,
       created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -140,6 +142,10 @@ export const socialTables: Record<string, string> = {
   // pre-existing tables (idempotent).
   feed_posts_message_column: `
     ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS message TEXT;
+  `,
+  // Challenge share posts (#994). Additive for pre-existing tables (idempotent).
+  feed_posts_challenge_column: `
+    ALTER TABLE feed_posts ADD COLUMN IF NOT EXISTS challenge JSONB;
   `,
   // `idx_feed_posts_series` is a GIN index over the shared-series set — the hot
   // path for the public series endpoint's `metric = ANY(series_metrics)` check.

--- a/apps/backend/src/services/activitypub/article-object.ts
+++ b/apps/backend/src/services/activitypub/article-object.ts
@@ -96,8 +96,10 @@ const sanitizeArticleHtml = (html: string): string =>
  * Render one run of authored markdown to sanitised, federation-safe HTML. Options
  * (GFM + hard line breaks) are passed per call, matching the web's `renderMarkdown`
  * (#910) without mutating `marked`'s process-wide defaults for every other importer.
+ * Exported for the challenge-share Note, whose personal note is markdown through
+ * the same pipeline (#994).
  */
-const renderProse = (markdown: string): string =>
+export const renderProse = (markdown: string): string =>
   sanitizeArticleHtml(marked.parse(markdown, { async: false, breaks: true, gfm: true }))
 
 /**

--- a/apps/backend/src/services/activitypub/challenge-object.test.ts
+++ b/apps/backend/src/services/activitypub/challenge-object.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+
+import { renderChallengeShareHtml } from './challenge-object.ts'
+
+const challenge = { name: 'August 10k steps', url: 'https://aurboda.net/u/fiddur/august-10k' }
+
+describe('renderChallengeShareHtml', () => {
+  test('renders name heading, sanitised markdown note, and the canonical link', () => {
+    const html = renderChallengeShareHtml(challenge, 'Join me — **every step counts**!')
+    expect(html).toContain('<p><strong>August 10k steps</strong></p>')
+    expect(html).toContain('<strong>every step counts</strong>')
+    expect(html).toContain(`<a href="${challenge.url}"`)
+    expect(html).toContain('rel="nofollow noopener noreferrer"')
+  })
+
+  test('omits the note paragraph when there is no message', () => {
+    const html = renderChallengeShareHtml(challenge, null)
+    expect(html).toBe(
+      '<p><strong>August 10k steps</strong></p>\n' +
+        `<p><a href="${challenge.url}" rel="nofollow noopener noreferrer" target="_blank">${challenge.url}</a></p>`,
+    )
+  })
+
+  test('escapes an HTML-ish challenge name and strips scripts from the note (XSS boundary)', () => {
+    const html = renderChallengeShareHtml(
+      { name: '<img src=x onerror=alert(1)> race', url: 'https://h.example/u/a/x' },
+      'note <script>alert(1)</script> end',
+    )
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('<script')
+    expect(html).toContain('&lt;img')
+    expect(html).toContain('note ')
+    expect(html).toContain(' end')
+  })
+})

--- a/apps/backend/src/services/activitypub/challenge-object.ts
+++ b/apps/backend/src/services/activitypub/challenge-object.ts
@@ -1,0 +1,23 @@
+/**
+ * The AS2 `content` for a challenge-share post (#994): the challenge name as a
+ * bold heading, the author's personal note rendered from markdown through the
+ * same outbound sanitiser as article prose (`renderProse` — #910's boundary),
+ * and the challenge's canonical public URL as a plain link. Mastodon renders
+ * the link with the challenge page's existing OG preview card; anyone joining
+ * follows the normal public-page / join-by-URL flow. No attachments and no
+ * standings data in phase 1.
+ */
+import type { ChallengeShare } from '@aurboda/api-spec'
+
+import { renderProse } from './article-object.ts'
+import { escapeXml } from '../charts/chart-svg.ts'
+
+/** The Note `content` HTML for a challenge share. `message` is authored markdown. */
+export const renderChallengeShareHtml = (challenge: ChallengeShare, message: string | null): string => {
+  const parts = [`<p><strong>${escapeXml(challenge.name)}</strong></p>`]
+  if (message) parts.push(renderProse(message))
+  parts.push(
+    `<p><a href="${escapeXml(challenge.url)}" rel="nofollow noopener noreferrer" target="_blank">${escapeXml(challenge.url)}</a></p>`,
+  )
+  return parts.join('\n')
+}

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -6,8 +6,11 @@ import { describe, expect, test } from 'vitest'
 import {
   buildArticleNote,
   buildArticleNoteCreate,
+  buildChallengeNote,
+  buildChallengeNoteCreate,
   buildFeedDelete,
   type DeliverableArticle,
+  type DeliverableChallenge,
   type DeliverablePost,
   imageAttachments,
   recipients,
@@ -192,5 +195,48 @@ describe('article delivery', () => {
     const object = await create.getObject()
     expect(object).toBeInstanceOf(Note)
     expect(object?.id?.href).toBe(noteId)
+  })
+})
+
+describe('buildChallengeNote / buildChallengeNoteCreate', () => {
+  const ORIGIN = 'https://aurboda.example'
+  const contextFor = () => createFeedFederation(ORIGIN, `${ORIGIN}/api`).createContext(new URL(ORIGIN))
+
+  const deliverableChallenge = (
+    visibility: DeliverableChallenge['visibility'],
+    message: string | null = 'Join me — **daily**!',
+  ): DeliverableChallenge => ({
+    challenge: { name: 'August 10k', url: `${ORIGIN}/u/fiddur/august-10k` },
+    created_at: new Date('2026-08-01T00:00:00Z'),
+    id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    message,
+    updated_at: new Date('2026-08-01T00:00:00Z'),
+    visibility,
+  })
+
+  test('is a Note at the canonical post id with name + note + link content', async () => {
+    const ctx = await contextFor()
+    const post = deliverableChallenge('public')
+    const note = buildChallengeNote(ctx, 'fiddur', post)
+
+    const noteId = `${ORIGIN}/users/fiddur/feed/${post.id}`
+    expect(note).toBeInstanceOf(Note)
+    expect(note.id?.href).toBe(noteId)
+    expect(note.name).toBe('August 10k')
+    expect(note.content?.toString()).toContain('<p><strong>August 10k</strong></p>')
+    expect(note.content?.toString()).toContain('<strong>daily</strong>')
+    expect(note.content?.toString()).toContain(`${ORIGIN}/u/fiddur/august-10k`)
+    expect(hrefs([...note.toIds])).toContain(PUBLIC)
+  })
+
+  test('the Create wraps the Note with a distinct #create id, addressed by visibility', async () => {
+    const ctx = await contextFor()
+    const post = deliverableChallenge('followers', null)
+    const create = buildChallengeNoteCreate(ctx, 'fiddur', post)
+    expect(create.id?.href).toBe(`${ORIGIN}/users/fiddur/feed/${post.id}#create`)
+    expect(hrefs([...create.toIds])).toEqual([`${ORIGIN}/users/fiddur/followers`])
+    expect([...create.ccIds]).toEqual([])
+    const object = await create.getObject()
+    expect(object).toBeInstanceOf(Note)
   })
 })

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -1,4 +1,4 @@
-import type { ArticleContent, FeedVisibility } from '@aurboda/api-spec'
+import type { ArticleContent, ChallengeShare, FeedVisibility } from '@aurboda/api-spec'
 /**
  * Build and deliver a shared feed post over ActivityPub.
  *
@@ -26,6 +26,7 @@ import type { FeedPostRecord } from '../../db/index.ts'
 
 import { getSettings } from '../settings.ts'
 import { articleImageAttachments, renderArticleContentHtml } from './article-object.ts'
+import { renderChallengeShareHtml } from './challenge-object.ts'
 import { resolveActivityScalars } from './feed-activity.ts'
 import { addressingFor, feedPostContent, formatActivityWindow, isPubliclyVisible } from './object.ts'
 import { dateToTemporalInstant } from './temporal-interop.ts'
@@ -399,4 +400,110 @@ export const deliverFeedArticleUpdate = async (
     'followers',
     buildArticleNoteUpdate(ctx, user, post, deps.apiBaseUrl),
   )
+}
+
+// ---------------------------------------------------------------------------
+// Challenge shares (#994). A challenge invitation federates as a `Note` (like
+// an article): the user's markdown note + the challenge's canonical public
+// URL. Mastodon renders the link with the challenge page's existing OG preview
+// card. Served on the SAME object path as every post kind, so it tombstones
+// like any post. No activity to resolve and no attachments in phase 1.
+// ---------------------------------------------------------------------------
+
+/** The delivery-facing view of a challenge post (its `challenge` guaranteed present). */
+export interface DeliverableChallenge {
+  id: string
+  visibility: FeedVisibility
+  created_at: Date
+  updated_at: Date
+  challenge: ChallengeShare
+  message: string | null
+}
+
+/** Narrow a stored feed post to a `DeliverableChallenge`, or null when it isn't one. */
+export const toDeliverableChallenge = (post: FeedPostRecord): DeliverableChallenge | null =>
+  post.kind === 'challenge' && post.challenge != null
+    ? {
+        challenge: post.challenge,
+        created_at: post.created_at,
+        id: post.id,
+        message: post.message,
+        updated_at: post.updated_at,
+        visibility: post.visibility,
+      }
+    : null
+
+/**
+ * Build the Fedify `Note` for a challenge share: name heading + sanitised
+ * markdown note + canonical link as `content`, addressed per visibility, at the
+ * post's canonical Note id. Synchronous — nothing to resolve.
+ */
+export const buildChallengeNote = (ctx: Context<void>, user: string, post: DeliverableChallenge): Note => {
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Note({
+    attribution: ctx.getActorUri(user),
+    ccs: cc,
+    content: renderChallengeShareHtml(post.challenge, post.message),
+    id: noteId,
+    name: post.challenge.name,
+    published: dateToTemporalInstant(post.created_at),
+    tos: to,
+    url: noteId,
+  })
+}
+
+/** Wrap the challenge Note in the `Create` delivered to followers and listed in the outbox. */
+export const buildChallengeNoteCreate = (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverableChallenge,
+): Create => {
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Create({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${noteId.href}#create`),
+    object: buildChallengeNote(ctx, user, post),
+    published: dateToTemporalInstant(post.created_at),
+    tos: to,
+  })
+}
+
+/** Wrap the challenge Note in an `Update`; id carries `updated_at` so each edit is distinct. */
+export const buildChallengeNoteUpdate = (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverableChallenge,
+): Update => {
+  const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
+  const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
+  return new Update({
+    actor: ctx.getActorUri(user),
+    ccs: cc,
+    id: new URL(`${noteId.href}#update-${post.updated_at.getTime()}`),
+    object: buildChallengeNote(ctx, user, post),
+    tos: to,
+  })
+}
+
+/** Build and send the `Create{Note}` for a freshly-shared challenge to followers. */
+export const deliverFeedChallengePost = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverableChallenge,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  await ctx.sendActivity({ identifier: user }, 'followers', buildChallengeNoteCreate(ctx, user, post))
+}
+
+/** Build and send the `Update{Note}` for an edited challenge share to followers. */
+export const deliverFeedChallengeUpdate = async (
+  deps: FeedDeliveryDeps,
+  user: string,
+  post: DeliverableChallenge,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  await ctx.sendActivity({ identifier: user }, 'followers', buildChallengeNoteUpdate(ctx, user, post))
 }

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -65,9 +65,12 @@ import { extractActorPresentation } from './actor-presentation.ts'
 import {
   buildArticleNote,
   buildArticleNoteCreate,
+  buildChallengeNote,
+  buildChallengeNoteCreate,
   buildFeedCreate,
   buildFeedNote,
   toDeliverableArticle,
+  toDeliverableChallenge,
 } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
 import { isPubliclyVisible } from './object.ts'
@@ -392,6 +395,8 @@ export const createFeedFederation = (
       // other). An article's Note is built from its stored content — no activity.
       const article = toDeliverableArticle(post)
       if (article != null) return buildArticleNote(ctx, identifier, article, apiBaseUrl)
+      const challenge = toDeliverableChallenge(post)
+      if (challenge != null) return buildChallengeNote(ctx, identifier, challenge)
       if (post.activity_id == null) return null
       // Resolve the merged-span activity so the served Note matches what the user
       // shared (and what we delivered), not just the anchor sub-activity (#881).
@@ -430,6 +435,8 @@ export const createFeedFederation = (
             // resolved activity.
             const article = toDeliverableArticle(post)
             if (article != null) return buildArticleNoteCreate(ctx, identifier, article, apiBaseUrl)
+            const challenge = toDeliverableChallenge(post)
+            if (challenge != null) return buildChallengeNoteCreate(ctx, identifier, challenge)
             if (post.activity_id == null) return null
             const activity = await resolveFeedActivity(identifier, post.activity_id)
             return activity == null ? null : buildFeedCreate(ctx, identifier, post, activity, apiBaseUrl)

--- a/apps/backend/src/services/challenge-share.ts
+++ b/apps/backend/src/services/challenge-share.ts
@@ -1,0 +1,57 @@
+/**
+ * Resolve what a challenge-share post links to (#994) — shared by the REST
+ * `POST /feed/challenges` route and the MCP `share_challenge` tool (parity).
+ *
+ * The name/URL are resolved server-side from the user's own challenge (its
+ * canonical public share URL) or from a joined challenge's stored
+ * participation (the host's URL + identity) — never client-supplied, so a post
+ * can never carry a spoofed link. Deliberately excludes join tokens and
+ * standings data.
+ */
+import type { ChallengeShare } from '@aurboda/api-spec'
+
+import { getChallengeById, getParticipationById } from '../db/index.ts'
+import { buildShareUrl } from './share-urls.ts'
+
+export interface ChallengeShareSource {
+  challenge_id?: string
+  participation_id?: string
+}
+
+export type ResolvedChallengeShare =
+  | { ok: true; challenge: ChallengeShare }
+  | { ok: false; error: string; status: 400 | 404 | 503 }
+
+/** Resolve the share payload from exactly one of `challenge_id`/`participation_id`. */
+export const resolveChallengeShare = async (
+  user: string,
+  source: ChallengeShareSource,
+  webHost: string | undefined,
+): Promise<ResolvedChallengeShare> => {
+  const { challenge_id, participation_id } = source
+  if ((challenge_id == null) === (participation_id == null)) {
+    return { error: 'Provide exactly one of challenge_id or participation_id', ok: false, status: 400 }
+  }
+  if (challenge_id != null) {
+    if (!webHost) return { error: 'Sharing is not available', ok: false, status: 503 }
+    const challenge = await getChallengeById(user, challenge_id)
+    if (!challenge) return { error: 'Challenge not found', ok: false, status: 404 }
+    return { challenge: { name: challenge.name, url: buildShareUrl(webHost, user, challenge.slug) }, ok: true }
+  }
+  if (participation_id != null) {
+    const participation = await getParticipationById(user, participation_id)
+    if (!participation) {
+      return { error: 'Challenge participation not found', ok: false, status: 404 }
+    }
+    return {
+      challenge: {
+        host_identity: participation.host_identity,
+        name: participation.name,
+        url: participation.challenge_url,
+      },
+      ok: true,
+    }
+  }
+  // Unreachable after the exactly-one guard; keeps the return type total.
+  return { error: 'Provide exactly one of challenge_id or participation_id', ok: false, status: 400 }
+}

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -184,6 +184,8 @@ export const serializeFeedPost = async (
     // The stored article payload (title + default window + blocks); present only
     // for `article` posts, which carry no activity and so no resolved `content`.
     article: record.article ?? undefined,
+    // The stored challenge link payload; present only for `challenge` posts.
+    challenge: record.challenge ?? undefined,
     content,
     created_at: record.created_at.toISOString(),
     id: record.id,

--- a/apps/web/src/components/ShareActivityDialog.css
+++ b/apps/web/src/components/ShareActivityDialog.css
@@ -143,3 +143,26 @@
     border-color: #374151;
   }
 }
+
+/* Challenge-share preview card (#994): a bordered mini-render of the post. */
+.share-dialog-preview {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.share-dialog-preview p {
+  margin: 0 0 0.4rem;
+}
+
+.share-dialog-preview p:last-child {
+  margin-bottom: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .share-dialog-preview {
+    border-color: #374151;
+  }
+}

--- a/apps/web/src/components/ShareChallengeDialog.tsx
+++ b/apps/web/src/components/ShareChallengeDialog.tsx
@@ -1,0 +1,132 @@
+/**
+ * Share a challenge to the user's federated feed (#994): a personal note
+ * (markdown, previewed through the shared sanitiser) plus the challenge's
+ * canonical join-by-URL link, with the usual feed audience choice. The server
+ * resolves the linked name/URL from the challenge (or joined participation)
+ * itself — the dialog only sends which one to share.
+ */
+import type { FeedVisibility } from '@aurboda/api-spec'
+
+import { feedPostMessageMaxLength } from '@aurboda/api-spec'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'preact/hooks'
+
+import { shareChallenge } from '../state/api'
+import { renderMarkdown } from '../utils/markdown'
+import { FEED_VISIBILITY_OPTIONS, VisibilitySelector } from './VisibilitySelector'
+import './ShareActivityDialog.css'
+
+interface Props {
+  /** One of the user's own challenges (exclusive with `participationId`). */
+  challengeId?: string
+  /** A challenge the user joined (exclusive with `challengeId`). */
+  participationId?: string
+  /** Shown in the dialog and the preview; the server resolves its own copy. */
+  challengeName: string
+  /** Shown in the preview; the server resolves its own copy. */
+  challengeUrl: string
+  onClose: () => void
+}
+
+export function ShareChallengeDialog({
+  challengeId,
+  participationId,
+  challengeName,
+  challengeUrl,
+  onClose,
+}: Props) {
+  const queryClient = useQueryClient()
+  const [message, setMessage] = useState('')
+  const [visibility, setVisibility] = useState<FeedVisibility>('public')
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      shareChallenge({
+        challenge_id: challengeId,
+        message,
+        participation_id: participationId,
+        visibility,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+      onClose()
+    },
+  })
+
+  return (
+    <div class="share-dialog-backdrop" onClick={onClose}>
+      <div class="share-dialog" onClick={(e) => e.stopPropagation()}>
+        <div class="share-dialog-header">
+          <h2>Share challenge</h2>
+          <button type="button" class="share-dialog-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <p class="share-dialog-subtitle">
+          Invite your followers to <strong>{challengeName}</strong> — the post links to the challenge page,
+          where anyone can join.
+        </p>
+
+        <fieldset class="share-dialog-group">
+          <legend>Message</legend>
+          <p class="share-dialog-note">Optional note shown above the link. Markdown works.</p>
+          <textarea
+            class="share-dialog-message"
+            rows={4}
+            maxLength={feedPostMessageMaxLength}
+            value={message}
+            onInput={(e) => setMessage((e.target as HTMLTextAreaElement).value)}
+            placeholder="Why should people join?"
+          />
+        </fieldset>
+
+        <fieldset class="share-dialog-group">
+          <legend>Preview</legend>
+          <div class="share-dialog-preview">
+            <p>
+              <strong>{challengeName}</strong>
+            </p>
+            {message.trim() !== '' && (
+              // Same sanitising renderer as article prose (#910) — the backend
+              // runs the authored markdown through its own equivalent boundary.
+              <div dangerouslySetInnerHTML={{ __html: renderMarkdown(message) }} />
+            )}
+            <p>
+              <a href={challengeUrl} target="_blank" rel="noopener noreferrer">
+                {challengeUrl}
+              </a>
+            </p>
+          </div>
+        </fieldset>
+
+        <VisibilitySelector
+          name="challenge-share-visibility"
+          options={FEED_VISIBILITY_OPTIONS}
+          value={visibility}
+          onChange={setVisibility}
+        />
+
+        {mutation.error && (
+          <p class="share-dialog-error">
+            {mutation.error instanceof Error ? mutation.error.message : 'Failed to share'}
+          </p>
+        )}
+
+        <div class="share-dialog-actions">
+          <button type="button" class="btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn-primary"
+            disabled={mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            {mutation.isPending ? 'Sharing…' : 'Share'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/Challenges/index.tsx
+++ b/apps/web/src/pages/Challenges/index.tsx
@@ -18,6 +18,7 @@ import { useState } from 'preact/hooks'
 
 import { ActivityTypePicker } from '../../components/ActivityTypePicker'
 import { MetricPicker } from '../../components/MetricPicker'
+import { ShareChallengeDialog } from '../../components/ShareChallengeDialog'
 import { SHARE_VISIBILITY_OPTIONS, VisibilitySelector } from '../../components/VisibilitySelector'
 import {
   createChallenge,
@@ -196,6 +197,7 @@ function CreateChallengeForm({ onCreated }: { onCreated: () => void }) {
 function HostedRow({ challenge }: { challenge: Challenge }) {
   const queryClient = useQueryClient()
   const [copied, setCopied] = useState(false)
+  const [sharing, setSharing] = useState(false)
   const del = useMutation({
     mutationFn: () => deleteChallenge(challenge.id),
     onError: () => alert('Failed to delete the challenge.'),
@@ -231,16 +233,28 @@ function HostedRow({ challenge }: { challenge: Challenge }) {
         <button class="btn-secondary" onClick={copy}>
           {copied ? 'Copied!' : 'Copy link'}
         </button>
+        <button class="btn-secondary" onClick={() => setSharing(true)}>
+          Share to feed
+        </button>
         <button class="btn-danger" onClick={() => confirm(`Delete "${challenge.name}"?`) && del.mutate()}>
           Delete
         </button>
       </div>
+      {sharing && (
+        <ShareChallengeDialog
+          challengeId={challenge.id}
+          challengeName={challenge.name}
+          challengeUrl={challenge.share_url}
+          onClose={() => setSharing(false)}
+        />
+      )}
     </li>
   )
 }
 
 function JoinedRow({ participation }: { participation: ChallengeParticipation }) {
   const queryClient = useQueryClient()
+  const [sharing, setSharing] = useState(false)
   const leave = useMutation({
     mutationFn: () => leaveChallenge(participation.id),
     onError: () => alert('Failed to leave the challenge.'),
@@ -259,6 +273,9 @@ function JoinedRow({ participation }: { participation: ChallengeParticipation })
         <a class="btn-secondary" href={participation.challenge_url}>
           View
         </a>
+        <button class="btn-secondary" onClick={() => setSharing(true)}>
+          Share to feed
+        </button>
         <button
           class="btn-danger"
           onClick={() => confirm(`Leave "${participation.name}"?`) && leave.mutate()}
@@ -266,6 +283,14 @@ function JoinedRow({ participation }: { participation: ChallengeParticipation })
           Leave
         </button>
       </div>
+      {sharing && (
+        <ShareChallengeDialog
+          participationId={participation.id}
+          challengeName={participation.name}
+          challengeUrl={participation.challenge_url}
+          onClose={() => setSharing(false)}
+        />
+      )}
     </li>
   )
 }

--- a/apps/web/src/pages/Feed/ChallengeShareContent.tsx
+++ b/apps/web/src/pages/Feed/ChallengeShareContent.tsx
@@ -1,0 +1,29 @@
+/**
+ * Native body for a challenge-share post (#994): the challenge name, the
+ * author's markdown note (rendered through the shared sanitiser — #910), and
+ * the canonical join-by-URL link. Mirrors the federated Note's content, so the
+ * owner's card shows what followers see.
+ */
+import type { ChallengeShare } from '@aurboda/api-spec'
+
+import { renderMarkdown } from '../../utils/markdown'
+
+export const ChallengeShareContent = ({
+  challenge,
+  message,
+}: {
+  challenge: ChallengeShare
+  message?: string
+}) => (
+  <div class="feed-post-content">
+    <p class="feed-post-title">
+      <strong>{challenge.name}</strong>
+    </p>
+    {message && <div dangerouslySetInnerHTML={{ __html: renderMarkdown(message) }} />}
+    <p>
+      <a href={challenge.url} target="_blank" rel="noopener noreferrer">
+        {challenge.url}
+      </a>
+    </p>
+  </div>
+)

--- a/apps/web/src/pages/Feed/FeedPostCard.tsx
+++ b/apps/web/src/pages/Feed/FeedPostCard.tsx
@@ -16,6 +16,7 @@ import { API_URL } from '../../config'
 import { formatEntryWindow } from './activity-stats'
 import { ActivityStatGrid } from './ActivityStatGrid'
 import { ArticleContent } from './ArticleContent'
+import { ChallengeShareContent } from './ChallengeShareContent'
 import { structuredHasNativeHrChart, structuredHasNativeMap } from './timeline-structured'
 import { TimelineStructured } from './TimelineStructured'
 import './FeedPostCard.css'
@@ -116,6 +117,8 @@ export const FeedPostCard = ({
           fall back to the server-built, HTML-escaped `content`. */}
       {post.kind === 'article' && post.article ? (
         <ArticleContent article={post.article} />
+      ) : post.kind === 'challenge' && post.challenge ? (
+        <ChallengeShareContent challenge={post.challenge} message={post.message} />
       ) : post.structured ? (
         <TimelineStructured structured={post.structured} />
       ) : post.metrics ? (

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -12,6 +12,7 @@ import type {
   FollowingActor,
   FollowingResponse,
   ShareActivityBody,
+  ShareChallengeBody,
   TimelineResponse,
   UpdateArticleBody,
   UpdateFeedPostBody,
@@ -46,6 +47,15 @@ export const fetchFeed = async (cursor?: string): Promise<FeedPostsResponse> => 
     params: cursor === undefined ? {} : { cursor },
   })
   return response.data
+}
+
+/** Share a challenge invitation (your note + the canonical link) to the feed (#994). */
+export const shareChallenge = async (body: ShareChallengeBody): Promise<FeedPost> => {
+  const response = await axios.post<FeedPostResponse>(`${API_URL}/feed/challenges`, body, {
+    headers: authHeaders(),
+  })
+  if (!response.data.post) throw new Error('Share failed: no post returned')
+  return response.data.post
 }
 
 /** Update a shared post's metric selection, series opt-in, or visibility. */

--- a/docs/features/challenges.md
+++ b/docs/features/challenges.md
@@ -114,6 +114,15 @@ the backend directly need no extra config.
 - **Join buttons:** logged-in users on the host instance get a one-click **Join**;
   anyone can **Join from another instance** (enter your Aurboda host → you're sent
   to your own instance's `/challenges/join`, which does the federated join).
+- **Share to feed** (#994): every row on `/challenges` — hosted **and** joined — has a
+  **Share to feed** button that publishes an invitation to the federated feed: an
+  optional personal note (markdown, previewed in the dialog) plus the challenge's
+  canonical link, with the usual `public`/`unlisted`/`followers` audience. The server
+  resolves the linked name/URL from the challenge (or the joined participation) itself,
+  and never embeds a join token or standings data. Federates as a `Note`; Mastodon shows
+  the link with the challenge page's OG preview card. Also available as the
+  `share_challenge` MCP tool / `POST /feed/challenges`. See
+  [feed.md](feed.md#feed-posts) for the post model.
 
 ## Android widget
 

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -62,6 +62,17 @@ A feed post has a **`kind`**:
   the post's private capability token, which must never land in publicly-pasted text —
   make the article public or unlisted first.
 
+- **`challenge`** — an **invitation to a challenge** (#994): the author's personal note
+  (markdown, rendered through the same sanitiser as article prose) plus the challenge's
+  canonical public URL — one of the user's own challenges (its share URL) or a challenge
+  they joined (the host's URL), resolved **server-side** so a post can never carry a
+  spoofed link. The payload (name + URL, and the host identity for a joined challenge)
+  lives in a nullable `challenge` JSONB column; no join token and no standings data are
+  embedded — anyone following the link goes through the normal public page / join-by-URL
+  flow. Federates as a `Note` (Mastodon renders the link with the challenge page's
+  existing OG preview card). Shared via `POST /feed/challenges` (and the
+  `share_challenge` MCP tool) or the **Share to feed** button on the challenges page.
+
 An **`activity`** feed post references one of the user's activities and records the
 explicit metric selection that bounds what is shared:
 
@@ -537,6 +548,7 @@ Owner-facing (authenticated, scoped to the caller):
 | `GET /feed`                        | My feed posts, newest-first, keyset-paginated (`?cursor=` from the previous page's `next_cursor`); each post enriched with the shared activity's title/type, merged-span window, and full structured payload |
 | `POST /feed/activities/:id/share`  | Publish an activity with a chosen metric selection                                                                      |
 | `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart/correlation blocks)                                       |
+| `POST /feed/challenges`            | Share a **challenge invitation** (personal note + canonical link); exactly one of `challenge_id`/`participation_id`     |
 | `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                          |
 | `GET /feed/articles/:postId/export`| Export an article as paste-ready markdown (title + prose + one image link per block) for Reddit/text-only destinations  |
 | `PATCH /feed/:postId`              | Edit an activity post's selection / visibility / attachments                                                            |
@@ -571,7 +583,7 @@ Public / federation (unauthenticated):
 | `POST /users/:username/inbox` (+ `/inbox`)                   | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
-`create_article`, `update_article`, `export_article_markdown`, `update_feed_post`,
+`share_challenge`, `create_article`, `update_article`, `export_article_markdown`, `update_feed_post`,
 `delete_feed_post`, `list_following`, `follow_actor`, `unfollow_actor`, `list_followers`,
 `approve_follower`, `reject_follower`, and `list_timeline` — all backed by the same services as
 the REST routes (`create_article` / `update_article` ↔ `POST /feed/articles` / `PATCH
@@ -583,9 +595,11 @@ toggled with the `manually_approve_followers` user setting (`get_user_settings` 
 ## Storage
 
 Feed posts live in the user's own database in the `feed_posts` table. A `kind` column
-discriminates an `activity` post from an `article` post; an article's content (title +
-default window + ordered blocks) lives in a nullable `article` JSONB column, and its
-`activity_id`/metric columns stay empty. A nullable `message` column holds the author's
+discriminates an `activity` post from an `article` or `challenge` post; an article's
+content (title + default window + ordered blocks) lives in a nullable `article` JSONB
+column, a challenge share's link payload (name + canonical URL + optional host identity)
+in a nullable `challenge` JSONB column, and in both cases the `activity_id`/metric
+columns stay empty. A nullable `message` column holds the author's
 personal message (plain text; NULL when none was shared). `activity_id` is a
 **soft reference** (no foreign key): activities are soft-deleted and the series lookup
 re-checks `deleted_at` at query time, so a removed activity simply stops resolving rather

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -125,15 +125,76 @@ export type UpdateFeedPostBody = z.infer<typeof updateFeedPostBodySchema>
 /**
  * The kind of a feed post. `activity` (the default) shares one of the user's
  * activities; `article` is a long-form post carrying markdown prose and inline
- * chart blocks over locked time windows. Modelled as a post *kind* rather than a
- * separate entity so articles reuse the whole feed (visibility, federation, home
- * timeline, the public-profile feed, permalinks).
+ * chart blocks over locked time windows; `challenge` invites people to a
+ * challenge (a personal note plus the challenge's canonical join-by-URL link).
+ * Modelled as a post *kind* rather than a separate entity so every kind reuses
+ * the whole feed (visibility, federation, home timeline, the public-profile
+ * feed, permalinks).
  */
-export const feedPostKindSchema = z
-  .enum(['activity', 'article'])
-  .meta({ description: 'Feed post kind: an activity share or a long-form article', id: 'FeedPostKind' })
+export const feedPostKindSchema = z.enum(['activity', 'article', 'challenge']).meta({
+  description: 'Feed post kind: an activity share, a long-form article, or a challenge invitation',
+  id: 'FeedPostKind',
+})
 
 export type FeedPostKind = z.infer<typeof feedPostKindSchema>
+
+// =============================================================================
+// Challenge posts (share a challenge to the feed — #994)
+// =============================================================================
+
+/**
+ * The stored payload of a `challenge` post: what the post links to. A snapshot
+ * of the challenge's name plus its canonical public URL — the same join-by-URL
+ * target the challenge page shares — resolved server-side at share time (from
+ * the owner's own challenge, or from a joined remote challenge's
+ * participation), never client-supplied. Deliberately carries no join token or
+ * standings data; anyone following the link goes through the normal public
+ * page / join flow.
+ */
+export const challengeShareSchema = z
+  .object({
+    host_identity: z.string().max(200).optional().meta({
+      description:
+        "The hosting instance's identity (e.g. `@user@host`) when sharing a joined remote challenge",
+    }),
+    name: z.string().min(1).max(200).meta({ description: 'Challenge name at share time' }),
+    url: z
+      .string()
+      .url()
+      .max(500)
+      .meta({ description: "The challenge's canonical public page URL (the join-by-URL target)" }),
+  })
+  .meta({ id: 'ChallengeShare' })
+
+export type ChallengeShare = z.infer<typeof challengeShareSchema>
+
+/**
+ * Body for sharing a challenge to the feed. Exactly ONE of `challenge_id` (one
+ * of the user's own challenges) or `participation_id` (a challenge they joined,
+ * possibly hosted elsewhere) — the server resolves the linked name/URL itself,
+ * so a post can never carry a spoofed link.
+ */
+export const shareChallengeBodySchema = z
+  .object({
+    challenge_id: z
+      .string()
+      .uuid()
+      .optional()
+      .meta({ description: 'One of your own challenges to share (exclusive with `participation_id`)' }),
+    message: z.string().max(feedPostMessageMaxLength).optional().meta({
+      description:
+        'Personal note shown above the link (markdown, rendered through the shared sanitiser). Empty/absent shares no text.',
+    }),
+    participation_id: z
+      .string()
+      .uuid()
+      .optional()
+      .meta({ description: 'A challenge you joined to share (exclusive with `challenge_id`)' }),
+    visibility: feedVisibilitySchema.default('public'),
+  })
+  .meta({ id: 'ShareChallengeBody' })
+
+export type ShareChallengeBody = z.infer<typeof shareChallengeBodySchema>
 
 /** A prose block: a run of markdown, rendered through the shared sanitiser (#910). */
 export const articleProseBlockSchema = z
@@ -275,6 +336,9 @@ export const feedPostSchema = z
     article: articleContentSchema
       .optional()
       .meta({ description: 'Article content, present only for `article` posts' }),
+    challenge: challengeShareSchema
+      .optional()
+      .meta({ description: 'Challenge link payload, present only for `challenge` posts' }),
     // The exact HTML `content` that federates for this post (headline + shared
     // scalar summary), so a client can render the post WYSIWYG — matching what
     // Mastodon shows — instead of reconstructing it from the metric keys. Absent


### PR DESCRIPTION
Part of #994 (phase 1 — the issue stays open for the phase-2 structured `challenge` enrichment and the optional race-chart PNG).

A challenge was shareable only as a bare copy-link; it can now be published to the federated feed like an activity or article, with a personal note.

## Post model
- **New feed-post kind `challenge`** on the same `feed_posts` storage (additive `challenge JSONB` column, registered in `tableCreationOrder` — the schema guard test covers the pairing). The payload is a snapshot of the challenge **name + canonical public URL** (+ `host_identity` for a joined remote challenge).
- **Server-side link resolution**: the body carries exactly one of `challenge_id` (own challenge → `buildShareUrl(webHost, user, slug)`) or `participation_id` (joined challenge → its stored `challenge_url`), resolved by the shared `services/challenge-share.ts` — a post can never carry a client-spoofed link. **No join token and no standings data** are embedded; joining goes through the normal public-page flow.
- **The note is markdown** (issue requirement), reusing the `message` column: the federated Note renders it through the article-prose outbound sanitiser (`renderProse`, now exported — #910's boundary), the web through the shared DOMPurify `renderMarkdown` sink.

## Federation
- `Create{Note}`: bold name heading + sanitised note + plain link, addressed per visibility. Mastodon shows the link with the challenge page's **existing OG preview card** (no new meta work needed).
- Object dispatcher + outbox gained the challenge branch; the generic `PATCH /:postId` routes challenge edits through the new `updatedChallenge` deliver hook (like the article fix before it); `DELETE` tombstones unchanged (kind-agnostic).

## Surfaces (API/MCP/web parity)
- REST `POST /feed/challenges` + MCP `share_challenge`, both on the shared resolver + `createChallengePost`.
- Web: **Share to feed** on every `/challenges` row — hosted **and** joined — opening a dialog with the markdown note, a live sanitised **preview** of the post, and the `public`/`unlisted`/`followers` audience. The owner's feed card renders the post natively (name, note, link). A remote Aurboda/Mastodon receiver renders the delivered sanitised HTML as usual.
- Editing: message/visibility are editable via the generic PATCH / `update_feed_post` (no dedicated edit dialog in phase 1); Unshare retracts as usual.

## Tests
- `renderChallengeShareHtml` unit (markdown sanitisation, XSS boundary, name escaping, link rel).
- `buildChallengeNote`/`buildChallengeNoteCreate` against a real Fedify context (ids, addressing, content).
- Router integration (live DB): own-challenge share resolves the canonical URL, joined-participation share, exactly-one 400s, unknown 404s, generic PATCH federates via `updatedChallenge`.
- DB integration: `createChallengePost` round-trip + appears in owner and public listings.
- Whole-monorepo `pnpm check` green; all 581 web tests + backend activitypub/mcp/feed suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo