### PR TITLE
docs(fep): fix prior-art links (Open Pace 404 → edance/openpace; link FitPub)

### DIFF
--- a/docs/fep/quantpub.md
+++ b/docs/fep/quantpub.md
@@ -517,7 +517,7 @@ GET /api/public/freja/series?metric=stress&start=...&end=...&bucket=60s
 
 ## Prior art
 
-- **[Open Pace](https://codeberg.org/openpace)** and **FitPub** — federated
+- **[Open Pace](https://github.com/edance/openpace)** and **[FitPub](https://fitpub.social/)** — federated
   running/fitness publishing; single-domain (exercise) and product-shaped
   rather than a vocabulary for arbitrary metrics.
 - **[Endurain](https://github.com/joaovitoriasilva/endurain)** and


### PR DESCRIPTION
Fredrik's report: the FEP's Open Pace link (https://codeberg.org/openpace) 404s.

Verified and fixed:
- **Open Pace** → https://github.com/edance/openpace (the 🏃 Elixir run-tracking project, homepage openpace.co — confirmed live).
- **FitPub** → https://fitpub.social/ (confirmed 200).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo