### PR TITLE
feat(feed): live share preview in the Share dialog (#902)

### DIFF
--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -38,7 +38,12 @@ import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { resolveChallengeShare } from '../services/challenge-share.ts'
-import { getFeedPage, normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
+import {
+  getFeedPage,
+  normalizeFeedMessage,
+  previewActivityShare,
+  serializeFeedPost,
+} from '../services/feed.ts'
 import { serializeFollower } from '../services/followers.ts'
 import { serializeFollowing } from '../services/following.ts'
 import { getSettings } from '../services/settings.ts'
@@ -94,6 +99,22 @@ export const registerFeedTools = (server: McpServer, user: string, options: Feed
       // Fan out to followers (best-effort), same as the REST share route.
       deliver?.created(user, record, activity)
       return jsonResponse(await serializeFeedPost(user, record))
+    },
+  )
+
+  server.tool(
+    'preview_activity_share',
+    'Preview what sharing an activity WOULD federate — the exact post text (HTML) and resolved metric values for a given selection — without creating a post. Use before share_activity to show the user what leaves the instance.',
+    { activity_id: z.string().uuid().describe('The activity to preview'), ...shareActivityBodySchema.shape },
+    async ({ activity_id, ...body }) => {
+      const activity = await getActivityById(user, activity_id)
+      if (!activity) return errorResponse('Activity not found')
+      return jsonResponse(
+        await previewActivityShare(user, activity, {
+          included_metrics: body.included_metrics,
+          ...(body.message === undefined ? {} : { message: body.message }),
+        }),
+      )
     },
   )
 

--- a/apps/backend/src/routes/feed-router.integration.test.ts
+++ b/apps/backend/src/routes/feed-router.integration.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vit
  * spy covers the article fan-out branches (including `kind === 'article'` on the
  * generic `PATCH /:postId`); the actual AS2 delivery is unit-tested in `deliver`.
  */
+import { insertActivity } from '../db/activities/index.ts'
 import { createChallenge, createChallengeParticipation } from '../db/challenges.ts'
 import { createFeedPost } from '../db/feed.ts'
 import { insertTimeSeries } from '../db/time-series.ts'
@@ -240,6 +241,58 @@ describe('GET /feed/articles/:postId/export (Reddit/markdown export, C4)', () =>
     const res = await withBase.request.get(`/feed/articles/${created.body.post.id}/export`)
     expect(res.status).toBe(400)
     expect(res.body.error).toContain('followers-only')
+  })
+})
+
+describe('POST /feed/activities/:id/preview (live share preview — #902)', () => {
+  let app: ReturnType<typeof startApp>
+
+  beforeAll(async () => {
+    await startTestDb()
+    app = startApp()
+  }, CONTAINER_TIMEOUT)
+
+  afterAll(async () => {
+    await app.close()
+    await stopTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanTestDb()
+  })
+
+  test('returns the EXACT content a share of the same selection would federate', async () => {
+    const user = getTestUser()
+    const activityId = await insertActivity(user, {
+      activity_type: 'running',
+      end_time: new Date('2026-08-01T08:30:00Z'),
+      source: 'garmin',
+      start_time: new Date('2026-08-01T08:00:00Z'),
+      title: 'Morning run',
+    })
+    const selection = { included_metrics: ['duration'], message: 'So good!', visibility: 'public' }
+
+    const preview = await app.request.post(`/feed/activities/${activityId}/preview`).send(selection)
+    expect(preview.status).toBe(200)
+    expect(preview.body.content).toContain('<strong>Morning run</strong>')
+    expect(preview.body.content).toContain('<p>So good!</p>')
+    expect(preview.body.metrics).toEqual([expect.objectContaining({ key: 'duration', value: 1800 })])
+
+    // Nothing was created…
+    const listBefore = await app.request.get('/feed')
+    expect(listBefore.body.posts).toEqual([])
+
+    // …and an actual share of the same selection federates the same content.
+    const shared = await app.request.post(`/feed/activities/${activityId}/share`).send(selection)
+    expect(shared.status).toBe(200)
+    expect(shared.body.post.content).toBe(preview.body.content)
+  })
+
+  test('404s for an unknown activity', async () => {
+    const res = await app.request
+      .post('/feed/activities/11111111-2222-4333-8444-555555555555/preview')
+      .send({ included_metrics: ['duration'] })
+    expect(res.status).toBe(404)
   })
 })
 

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -19,6 +19,7 @@ import {
   type FeedPostsResponse,
   type ShareActivityBody,
   shareActivityBodySchema,
+  type SharePreviewResponse,
   type ShareChallengeBody,
   shareChallengeBodySchema,
   type TimelineQuery,
@@ -47,7 +48,12 @@ import { isPubliclyVisible } from '../services/activitypub/object.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { resolveChallengeShare } from '../services/challenge-share.ts'
-import { getFeedPage, normalizeFeedMessage, serializeFeedPost } from '../services/feed.ts'
+import {
+  getFeedPage,
+  normalizeFeedMessage,
+  previewActivityShare,
+  serializeFeedPost,
+} from '../services/feed.ts'
 import { getSettings } from '../services/settings.ts'
 import { getTimelinePage } from '../services/timeline.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
@@ -189,6 +195,26 @@ export const createFeedRouter = (
       // Fan the post out to followers (best-effort; never blocks the response).
       deliver?.created(user, record, activity)
       res.json({ post: await serializeFeedPost(user, record, { includeStructured: true }), success: true })
+    },
+  )
+
+  // Live share preview (#902): what would this selection federate? Resolves the
+  // exact content/scalars the share would produce, creates nothing.
+  router.post<{ id: string }, SharePreviewResponse, ShareActivityBody>(
+    '/activities/:id/preview',
+    authMiddleware,
+    validateBody(shareActivityBodySchema),
+    async (req, res) => {
+      const user = req.user!
+      const activity = await getActivityById(user, req.params.id)
+      if (!activity) {
+        return res.status(404).json({ error: 'Activity not found', success: false })
+      }
+      const preview = await previewActivityShare(user, activity, {
+        included_metrics: req.body.included_metrics,
+        ...(req.body.message === undefined ? {} : { message: req.body.message }),
+      })
+      res.json({ content: preview.content, metrics: preview.metrics, success: true })
     },
   )
 

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -236,3 +236,32 @@ export const getFeedPage = async (
     posts: await Promise.all(page.map((record) => serializeFeedPost(user, record, opts))),
   }
 }
+
+/**
+ * Resolve what a share of `activity` with `selection` WOULD federate (#902):
+ * the exact `content` HTML (via the same `feedPostContent` used for delivery
+ * and the owner card) and the typed scalars — without creating a post. Backs
+ * the Share dialog's live preview, so what the user sees before clicking
+ * Share is byte-for-byte what leaves the instance.
+ */
+export const previewActivityShare = async (
+  user: string,
+  activity: Activity,
+  selection: { included_metrics: string[]; message?: string },
+): Promise<{ content: string; metrics: FeedPost['metrics'] }> => {
+  const window = await expandFeedActivityWindow(user, activity)
+  const scalars = await resolveActivityScalars(
+    user,
+    { end_time: window.end_time, start_time: window.start_time },
+    selection.included_metrics,
+  )
+  const settings = await getSettings(user).catch(() => null)
+  const content = feedPostContent(window.title, window.activity_type, scalars, {
+    message: normalizeFeedMessage(selection.message) ?? undefined,
+    windowLabel: formatActivityWindow(window.start_time, window.end_time, settings?.device_timezone),
+  }).content
+  return {
+    content,
+    metrics: scalars.map(({ key, unit, value }) => ({ key, value, ...(unit === undefined ? {} : { unit }) })),
+  }
+}

--- a/apps/web/src/components/ShareActivityDialog.tsx
+++ b/apps/web/src/components/ShareActivityDialog.tsx
@@ -13,9 +13,15 @@ import type { FeedPost, FeedVisibility, MetricType } from '@aurboda/api-spec'
 
 import { feedPostMessageMaxLength } from '@aurboda/api-spec'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
-import { fetchBucketedMetrics, fetchRawLocations, shareActivity, updateFeedPost } from '../state/api'
+import {
+  fetchBucketedMetrics,
+  fetchRawLocations,
+  previewShare,
+  shareActivity,
+  updateFeedPost,
+} from '../state/api'
 import {
   buildShareBody,
   defaultsFromChart,
@@ -152,19 +158,40 @@ export function ShareActivityDialog({
   // actually offered as a control here.
   const offersHeartRate = seriesOptions.some((m) => m.key === 'heart_rate')
 
+  const currentBody = () =>
+    buildShareBody({
+      canChart,
+      canMap,
+      includeMap,
+      message,
+      series,
+      seriesOptions,
+      summary,
+      summaryOptions,
+      visibility,
+    })
+
+  // Live preview (#902): the server resolves the EXACT federated content for
+  // the current selection (same code path as delivery), debounced so typing in
+  // the message doesn't fire a request per keystroke. Keyed on the serialised
+  // body — identical selections hit the react-query cache.
+  const [debouncedKey, setDebouncedKey] = useState('')
+  const bodyKey = JSON.stringify(currentBody())
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedKey(bodyKey), 400)
+    return () => clearTimeout(timer)
+  }, [bodyKey])
+  const previewQuery = useQuery({
+    enabled: debouncedKey !== '',
+    queryFn: () => previewShare(activityId, JSON.parse(debouncedKey)),
+    queryKey: ['share-preview', activityId, debouncedKey],
+    staleTime: 60_000,
+  })
+  const previewContent = previewQuery.data?.content
+
   const mutation = useMutation({
     mutationFn: () => {
-      const body = buildShareBody({
-        canChart,
-        canMap,
-        includeMap,
-        message,
-        series,
-        seriesOptions,
-        summary,
-        summaryOptions,
-        visibility,
-      })
+      const body = currentBody()
       return post ? updateFeedPost(post.id, body) : shareActivity(activityId, body)
     },
     onSuccess: (result) => {
@@ -268,6 +295,22 @@ export function ShareActivityDialog({
           value={visibility}
           onChange={setVisibility}
         />
+
+        <fieldset class="share-dialog-group">
+          <legend>Preview</legend>
+          <p class="share-dialog-note">
+            Exactly what a follower on Mastodon sees
+            {canMap && includeMap ? ' — plus the route-map image' : ''}
+            {canChart && series.has('heart_rate') ? ' and the heart-rate chart image' : ''}.
+          </p>
+          {previewContent ? (
+            // Server-built, HTML-escaped content of the user's OWN data — the
+            // same trusted string the owner feed card renders (#902).
+            <div class="share-dialog-preview" dangerouslySetInnerHTML={{ __html: previewContent }} />
+          ) : (
+            <p class="share-dialog-note">{previewQuery.isError ? 'Preview unavailable.' : 'Loading…'}</p>
+          )}
+        </fieldset>
 
         {mutation.error && (
           <p class="share-dialog-error">

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -13,6 +13,7 @@ import type {
   FollowingResponse,
   ShareActivityBody,
   ShareChallengeBody,
+  SharePreviewResponse,
   TimelineResponse,
   UpdateArticleBody,
   UpdateFeedPostBody,
@@ -46,6 +47,22 @@ export const fetchFeed = async (cursor?: string): Promise<FeedPostsResponse> => 
     headers: authHeaders(),
     params: cursor === undefined ? {} : { cursor },
   })
+  return response.data
+}
+
+/**
+ * Preview what sharing `activityId` with this selection would federate (#902):
+ * the exact post HTML + resolved metric values. Creates nothing.
+ */
+export const previewShare = async (
+  activityId: string,
+  body: ShareActivityBody,
+): Promise<SharePreviewResponse> => {
+  const response = await axios.post<SharePreviewResponse>(
+    `${API_URL}/feed/activities/${activityId}/preview`,
+    body,
+    { headers: authHeaders() },
+  )
   return response.data
 }
 

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -496,7 +496,9 @@ resolving.
 - **Share** — an activity's detail page has a **Share to feed** button. It opens a dialog
   to write an optional personal message (prefilled from the activity's description /
   comments, fully editable), pick the summary metrics, optionally opt into full series,
-  and choose the audience. The **owner's own feed** renders each activity post with the
+  and choose the audience — with a **live preview** (#902) of the exact federated
+  content (resolved server-side through the same code path as delivery, debounced) and
+  which images would attach, so what leaves the instance is visible before Share. The **owner's own feed** renders each activity post with the
   **same native card component a subscribing Aurboda peer's timeline uses** — the owner-facing
   feed responses include the full structured payload (typed scalars + inline series + route,
   assembled by the same helper the public structured endpoint uses), so the author sees the
@@ -548,6 +550,7 @@ Owner-facing (authenticated, scoped to the caller):
 | `GET /feed`                        | My feed posts, newest-first, keyset-paginated (`?cursor=` from the previous page's `next_cursor`); each post enriched with the shared activity's title/type, merged-span window, and full structured payload |
 | `POST /feed/activities/:id/share`  | Publish an activity with a chosen metric selection                                                                      |
 | `POST /feed/articles`              | Publish a long-form **article** (title + prose + inline chart/correlation blocks)                                       |
+| `POST /feed/activities/:id/preview`| Live share **preview** (#902): the exact federated content + resolved metrics for a selection; creates nothing          |
 | `POST /feed/challenges`            | Share a **challenge invitation** (personal note + canonical link); exactly one of `challenge_id`/`participation_id`     |
 | `GET/POST /autoshare-rules` (+`/:id`, `/preview`) | [Auto-share rules](auto-share-rules.md): automatically publish matching settled activities (#903)         |
 | `PATCH /feed/articles/:postId`     | Edit an article (title / blocks / default window / visibility)                                                          |
@@ -584,7 +587,7 @@ Public / federation (unauthenticated):
 | `POST /users/:username/inbox` (+ `/inbox`)                   | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
-`share_challenge`, `create_article`, `update_article`, `export_article_markdown`, `update_feed_post`,
+`preview_activity_share`, `share_challenge`, `create_article`, `update_article`, `export_article_markdown`, `update_feed_post`,
 `delete_feed_post`, `list_following`, `follow_actor`, `unfollow_actor`, `list_followers`,
 `approve_follower`, `reject_follower`, and `list_timeline` — all backed by the same services as
 the REST routes (`create_article` / `update_article` ↔ `POST /feed/articles` / `PATCH

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -422,6 +422,27 @@ export const feedPostsResponseSchema = baseResponseSchema
 export type FeedPostsResponse = z.infer<typeof feedPostsResponseSchema>
 
 /**
+ * Response for the share PREVIEW (#902): the exact federated `content` HTML a
+ * Mastodon follower would see and the typed scalars behind the native stat
+ * grid, resolved for a given share selection WITHOUT creating a post — so the
+ * dialog shows precisely what would leave the instance.
+ */
+export const sharePreviewResponseSchema = baseResponseSchema
+  .extend({
+    content: z
+      .string()
+      .optional()
+      .meta({ description: 'The AS2 `content` HTML the post would federate with' }),
+    metrics: z
+      .array(feedStructuredMetricSchema)
+      .optional()
+      .meta({ description: 'The resolved typed scalar values for the selection' }),
+  })
+  .meta({ id: 'SharePreviewResponse' })
+
+export type SharePreviewResponse = z.infer<typeof sharePreviewResponseSchema>
+
+/**
  * Body for creating an article post. No activity anchor and no shared
  * metrics/series — an article carries its own title, default window, and blocks.
  */


### PR DESCRIPTION
Closes #902

The Share dialog now shows **exactly what leaves the instance** before clicking Share.

- **`POST /feed/activities/:id/preview`** (+ MCP `preview_activity_share` — parity): resolves the exact federated `content` HTML and typed scalars for a given selection through the SAME `feedPostContent`/`resolveActivityScalars` path delivery uses — so the preview is byte-for-byte what a Mastodon follower would see (asserted by an integration test: preview `content` === a subsequent real share's `content`; nothing is created by the preview). Shared `previewActivityShare` service in `services/feed.ts`.
- **Dialog**: a Preview box below the audience selector — server-resolved, debounced 400 ms (no request per keystroke), react-query-cached per serialized selection, with a note saying which images (heart-rate chart / route map) would attach. The rendered HTML is the server-built, escaped content of the user's own data — the same trusted string the owner feed card already renders.
- Works in create AND edit mode (same resolution either way).
- The issue's "(b) chart/route images" half: the actual PNGs don't exist pre-post (they render per post id), so the preview states which images will attach; the interactive chart the user just configured is on the detail page behind the dialog. The federated text render — the part invisible until now — is the live half.

## Tests
- Integration: preview↔share content parity + nothing-created + 404 for unknown activity.
- Whole-monorepo `pnpm check` green; all 581 web tests + feed-router suite (19) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo