### PR TITLE
feat(feed): federate the QuantPub quant:Exercise extension + serve its @context (#896)

### DIFF
--- a/apps/backend/src/routes/well-known-router.test.ts
+++ b/apps/backend/src/routes/well-known-router.test.ts
@@ -40,3 +40,32 @@ describe('well-known/assetlinks.json', () => {
     expect(res.headers['cache-control']).toMatch(/max-age=3600/)
   })
 })
+
+describe('well-known/quantpub (#896)', () => {
+  const app = buildApp({ androidFingerprints: [], androidPackageName: 'net.aurboda.app' })
+
+  test('serves the QuantPub discovery document (FEP §4), cacheable', async () => {
+    const res = await supertest(app).get('/.well-known/quantpub')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      api_base: 'http://localhost:3000',
+      product: 'aurboda',
+      quantpub: '0.1',
+      version: 'test',
+    })
+    expect(res.headers['cache-control']).toMatch(/max-age=3600/)
+  })
+
+  test('serves the published JSON-LD @context at /ns/quantpub as application/ld+json', async () => {
+    const res = await supertest(app).get('/ns/quantpub')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toContain('application/ld+json')
+    expect(res.body).toEqual({
+      '@context': {
+        quant: 'https://w3id.org/quantpub#',
+        'quant:metrics': { '@type': '@json' },
+        'quant:series': { '@type': '@json' },
+      },
+    })
+  })
+})

--- a/apps/backend/src/routes/well-known-router.ts
+++ b/apps/backend/src/routes/well-known-router.ts
@@ -7,10 +7,11 @@
  *   signing fingerprints (e.g. for a custom-built APK) via the
  *   `ANDROID_APP_FINGERPRINTS` env var.
  */
-import type { WellKnownAurboda } from '@aurboda/api-spec'
+import type { WellKnownAurboda, WellKnownQuantpub } from '@aurboda/api-spec'
 
 import type { TypedRouter } from '../typed-router.ts'
 
+import { quantContextDocument, QUANTPUB_VERSION } from '../services/activitypub/quant-extension.ts'
 import { typedRouter } from '../typed-router.ts'
 
 export interface WellKnownConfig {
@@ -65,6 +66,27 @@ export const createWellKnownRouter = (config: WellKnownConfig): TypedRouter => {
       product: 'aurboda',
       version: config.version,
     })
+  })
+
+  // QuantPub discovery (FEP §4): lets any QuantPub peer — not just Aurboda —
+  // verify this host speaks the spec and locate the structured/series API base.
+  router.get<Record<string, never>, WellKnownQuantpub>('/.well-known/quantpub', (_req, res) => {
+    res.setHeader('Cache-Control', 'public, max-age=3600')
+    res.json({
+      api_base: config.apiBaseUrl,
+      product: 'aurboda',
+      quantpub: QUANTPUB_VERSION,
+      version: config.version,
+    })
+  })
+
+  // The published QuantPub JSON-LD @context document (FEP §1) — the canonical
+  // form of the inline `quant:` term definitions every delivered object embeds.
+  router.get<Record<string, never>, Record<string, unknown>>('/ns/quantpub', (_req, res) => {
+    res.setHeader('Cache-Control', 'public, max-age=3600')
+    // res.json only defaults the Content-Type when none is set, so this sticks.
+    res.setHeader('Content-Type', 'application/ld+json')
+    res.json(quantContextDocument)
   })
 
   return router

--- a/apps/backend/src/services/activitypub/deliver.test.ts
+++ b/apps/backend/src/services/activitypub/deliver.test.ts
@@ -51,6 +51,7 @@ describe('buildFeedDelete', () => {
     include_chart: false,
     include_map: false,
     included_metrics: [],
+    series_metrics: [],
     updated_at: new Date('2026-07-01T00:00:00Z'),
     visibility,
   })
@@ -95,6 +96,7 @@ describe('imageAttachments', () => {
     include_chart: false,
     include_map: false,
     included_metrics: [],
+    series_metrics: [],
     updated_at: new Date('2026-07-01T00:00:00Z'),
     visibility: 'public',
     ...overrides,

--- a/apps/backend/src/services/activitypub/deliver.ts
+++ b/apps/backend/src/services/activitypub/deliver.ts
@@ -13,9 +13,12 @@ import type { ArticleContent, ChallengeShare, FeedVisibility } from '@aurboda/ap
  * (no message queue configured), so it awaits the outbound POSTs; retry/
  * durability via a persistent queue is a later slice.
  *
- * The custom `aurboda:` structured extension is not carried on the Fedify `Note`
- * (its typed vocab drops unknown properties); that richer, Aurboda-native
- * representation lives in `object.ts` for a future content-negotiated endpoint.
+ * Every activity Note also carries the QuantPub `quant:` extension (#896):
+ * Fedify's typed vocab drops unknown properties, so `withQuantJsonLd` splices
+ * the typed fields into the serialized JSON-LD of the outermost object we hand
+ * to Fedify — the `Create`/`Update` for delivery and the outbox, the bare
+ * `Note` for the object dispatcher (see `quant-extension.ts`). The AS2 window
+ * (`startTime`/`endTime`) is set natively on the Note.
  * Delivery is best-effort: callers invoke it fire-and-forget.
  */
 import type { Context, Federation } from '@fedify/fedify'
@@ -29,6 +32,7 @@ import { articleImageAttachments, renderArticleContentHtml } from './article-obj
 import { renderChallengeShareHtml } from './challenge-object.ts'
 import { resolveActivityScalars } from './feed-activity.ts'
 import { addressingFor, feedPostContent, formatActivityWindow, isPubliclyVisible } from './object.ts'
+import { quantExerciseExtension, withQuantJsonLd } from './quant-extension.ts'
 import { dateToTemporalInstant } from './temporal-interop.ts'
 
 /**
@@ -52,6 +56,8 @@ export interface FeedDeliveryDeps {
 export interface DeliverablePost {
   id: string
   included_metrics: string[]
+  /** Metric keys whose series were explicitly shared (drive `quant:series` links). */
+  series_metrics: string[]
   visibility: FeedVisibility
   /** The author's personal message (plain text); null/undefined = none shared. */
   message?: string | null
@@ -128,13 +134,13 @@ export interface DeliverableActivity {
  * types `published` as the ambient `Temporal.Instant`; `dateToTemporalInstant`
  * bridges our `@js-temporal/polyfill` value to it.
  */
-export const buildFeedNote = async (
+const buildFeedNoteParts = async (
   ctx: Context<void>,
   user: string,
   post: DeliverablePost,
   activity: DeliverableActivity,
   apiBaseUrl: string,
-): Promise<Note> => {
+): Promise<{ note: Note; quant: Record<string, unknown> }> => {
   const scalars = await resolveActivityScalars(user, activity, post.included_metrics)
   // The activity-date line renders in the author's device timezone (like the
   // article block images); unknown/invalid falls back to UTC inside the formatter.
@@ -150,17 +156,45 @@ export const buildFeedNote = async (
   const actorUri = ctx.getActorUri(user)
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
-  return new Note({
+  const note = new Note({
     attachments: imageAttachments(apiBaseUrl, user, post),
     attribution: actorUri,
     ccs: cc,
     content,
+    // The AS2 activity window — the workout time; `published` stays the share time.
+    endTime: activity.end_time === undefined ? null : dateToTemporalInstant(activity.end_time),
     id: noteId,
     name,
     published: dateToTemporalInstant(post.created_at),
+    startTime: dateToTemporalInstant(activity.start_time),
     tos: to,
     url: noteId,
   })
+  const quant = quantExerciseExtension({
+    activityType: activity.activity_type,
+    apiBaseUrl,
+    endTime: activity.end_time,
+    imageToken: post.image_token,
+    postId: post.id,
+    scalars,
+    seriesMetrics: post.series_metrics,
+    startTime: activity.start_time,
+    user,
+    visibility: post.visibility,
+  })
+  return { note, quant }
+}
+
+export const buildFeedNote = async (
+  ctx: Context<void>,
+  user: string,
+  post: DeliverablePost,
+  activity: DeliverableActivity,
+  apiBaseUrl: string,
+): Promise<Note> => {
+  const { note, quant } = await buildFeedNoteParts(ctx, user, post, activity, apiBaseUrl)
+  // The dispatcher serves the Note bare, so the Note itself carries the extension.
+  return withQuantJsonLd(note, quant)
 }
 
 /**
@@ -176,10 +210,13 @@ export const buildFeedCreate = async (
   activity: DeliverableActivity,
   apiBaseUrl: string,
 ): Promise<Create> => {
-  const note = await buildFeedNote(ctx, user, post, activity, apiBaseUrl)
+  // The Create is the outermost serialized object, so IT carries the quant
+  // extension (spliced into its embedded object) — wrapping the embedded Note
+  // instead would be mangled by the activity-level JSON-LD compaction.
+  const { note, quant } = await buildFeedNoteParts(ctx, user, post, activity, apiBaseUrl)
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
-  return new Create({
+  const create = new Create({
     actor: ctx.getActorUri(user),
     ccs: cc,
     id: new URL(`${noteId.href}#create`),
@@ -187,6 +224,7 @@ export const buildFeedCreate = async (
     published: dateToTemporalInstant(post.created_at),
     tos: to,
   })
+  return withQuantJsonLd(create, quant)
 }
 
 /**
@@ -204,16 +242,17 @@ export const buildFeedUpdate = async (
   activity: DeliverableActivity,
   apiBaseUrl: string,
 ): Promise<Update> => {
-  const note = await buildFeedNote(ctx, user, post, activity, apiBaseUrl)
+  const { note, quant } = await buildFeedNoteParts(ctx, user, post, activity, apiBaseUrl)
   const noteId = ctx.getObjectUri(Note, { identifier: user, postId: post.id })
   const { cc, to } = recipients(post.visibility, ctx.getFollowersUri(user))
-  return new Update({
+  const update = new Update({
     actor: ctx.getActorUri(user),
     ccs: cc,
     id: new URL(`${noteId.href}#update-${post.updated_at.getTime()}`),
     object: note,
     tos: to,
   })
+  return withQuantJsonLd(update, quant)
 }
 
 /**

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -215,18 +215,88 @@ describe('Feed federation actor + WebFinger', () => {
     const res = await fetchAs2(`/users/${user}/feed/${post.id}`)
     expect(res.status).toBe(200)
     const doc = (await res.json()) as {
-      type: string
+      type: string | string[]
       id: string
       attributedTo?: string
       published?: string
     }
-    expect(doc.type).toBe('Note')
+    // Dual-typed Note-first: Mastodon renders the Note, QuantPub peers read the extension.
+    expect(doc.type).toEqual(['Note', 'quant:Exercise'])
     expect(doc.id).toBe(`${ORIGIN}/users/${user}/feed/${post.id}`)
     expect(doc.attributedTo).toBe(`${ORIGIN}/users/${user}`)
     // `published` is the post's share time (created_at), not the fetch time, so
     // remote servers order it correctly.
     expect(doc.published).toBeDefined()
     expect(new Date(doc.published ?? '').getTime()).toBe(post.created_at.getTime())
+  })
+
+  test('a served post object carries the QuantPub extension (#896)', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId, {
+      included_metrics: ['duration'],
+      series_metrics: ['heart_rate'],
+    })
+
+    const doc = (await (await fetchAs2(`/users/${user}/feed/${post.id}`)).json()) as {
+      '@context': unknown[]
+      startTime?: string
+      endTime?: string
+      'quant:activityType'?: string
+      'quant:metrics'?: { key: string; value: number; unit?: string }[]
+      'quant:series'?: { metric: string; href: string; mediaType: string }[]
+      'quant:structuredUrl'?: string
+    }
+    // The AS2 window is native (FEP reuses startTime/endTime), quant: terms ride the splice.
+    expect(new Date(doc.startTime ?? '').toISOString()).toBe('2026-07-01T06:30:00.000Z')
+    expect(new Date(doc.endTime ?? '').toISOString()).toBe('2026-07-01T07:11:00.000Z')
+    expect(doc['quant:activityType']).toBe('exercise')
+    expect(doc['quant:metrics']).toEqual([{ key: 'duration', unit: 'seconds', value: 2460 }])
+    expect(doc['quant:structuredUrl']).toBe(`${ORIGIN}/api/public/${user}/feed/${post.id}`)
+    const series = doc['quant:series'] ?? []
+    expect(series).toHaveLength(1)
+    expect(series[0].metric).toBe('heart_rate')
+    expect(series[0].href).toContain(`${ORIGIN}/api/public/${user}/series?`)
+    // The inline @context defines the quant prefix and the @json literal terms.
+    expect(doc['@context']).toContainEqual({
+      quant: 'https://w3id.org/quantpub#',
+      'quant:metrics': { '@type': '@json' },
+      'quant:series': { '@type': '@json' },
+    })
+  })
+
+  test('a followers-only delivery Note carries the token on quant:structuredUrl but no series', async () => {
+    const user = getTestUser()
+    const activityId = await insertExercise(user)
+    const post = await sharePost(user, activityId, {
+      included_metrics: ['duration'],
+      series_metrics: ['heart_rate'],
+      visibility: 'followers',
+    })
+
+    // A followers-only object never resolves publicly — build the delivered
+    // Update directly (same Note builder as the delivered Create).
+    const ctx = await fed.createContext(new URL(ORIGIN))
+    const update = await buildFeedUpdate(
+      ctx,
+      user,
+      post,
+      {
+        activity_type: 'exercise',
+        end_time: new Date('2026-07-01T07:11:00Z'),
+        start_time: new Date('2026-07-01T06:30:00Z'),
+        title: 'Morning run',
+      },
+      `${ORIGIN}/api`,
+    )
+    const doc = (await update.toJsonLd({ format: 'compact' })) as {
+      object?: { 'quant:structuredUrl'?: string; 'quant:series'?: unknown }
+    }
+    expect(doc.object?.['quant:structuredUrl']).toBe(
+      `${ORIGIN}/api/public/${user}/feed/${post.id}?token=${post.image_token}`,
+    )
+    // The public /series endpoint would 404 a followers-only post, so no links.
+    expect(doc.object?.['quant:series']).toBeUndefined()
   })
 
   test('federates an article as a Create{Note} in the outbox and serves its object (#937)', async () => {

--- a/apps/backend/src/services/activitypub/feed-activity.test.ts
+++ b/apps/backend/src/services/activitypub/feed-activity.test.ts
@@ -2,72 +2,7 @@ import { describe, expect, test } from 'vitest'
 
 import type { QueryMetricsBucketedResult } from '../queries/types.ts'
 
-import {
-  buildFeedPostActivity,
-  type FeedActivityContext,
-  type FeedActivityInput,
-  windowMetricStat,
-} from './feed-activity.ts'
-
-const ctx: FeedActivityContext = {
-  apiBaseUrl: 'https://aurboda.net/api/',
-  origin: 'https://aurboda.net/',
-  username: 'fiddur',
-}
-
-const input: FeedActivityInput = {
-  activityType: 'running',
-  endTime: new Date('2026-07-01T07:11:03Z'),
-  includedMetrics: ['duration', 'heart_rate_avg'],
-  postId: 'abc123',
-  publishedAt: new Date('2026-07-01T20:00:00Z'),
-  seriesMetrics: ['heart_rate'],
-  startTime: new Date('2026-07-01T06:30:00Z'),
-  title: 'Morning run',
-  visibility: 'public',
-}
-
-describe('buildFeedPostActivity', () => {
-  test('builds canonical /users/ URLs, series href, and resolves scalars', () => {
-    const c = buildFeedPostActivity(ctx, input, (metric, stat) =>
-      metric === 'heart_rate' && stat === 'avg' ? 148 : undefined,
-    )
-    // Trailing slashes on origin/apiBaseUrl are trimmed.
-    expect(c.actor).toBe('https://aurboda.net/users/fiddur')
-    expect(c.id).toBe('https://aurboda.net/users/fiddur/feed/abc123')
-    expect(c.object.id).toBe('https://aurboda.net/users/fiddur/feed/abc123/object')
-    expect(c['@context'][1]).toEqual({ aurboda: 'https://aurboda.net/ns/activitystreams#' })
-    // publishedAt drives the Create's published, workout time stays in aurboda:startTime.
-    expect(c.published).toBe('2026-07-01T20:00:00.000Z')
-    expect(c.object['aurboda:startTime']).toBe('2026-07-01T06:30:00.000Z')
-    // Shared scalars resolved (duration from window + injected HR avg).
-    expect(c.object['aurboda:metrics']).toEqual([
-      { key: 'duration', unit: 'seconds', value: 2463 },
-      { key: 'heart_rate_avg', unit: 'bpm', value: 148 },
-    ])
-    // Series href points at the public endpoint under the API base.
-    const series = c.object['aurboda:series'] as { href: string }[]
-    expect(series[0].href).toContain('https://aurboda.net/api/public/fiddur/series?')
-    expect(series[0].href).toContain('metric=heart_rate')
-  })
-
-  test('carries the personal message and renders the date line in the given timezone (#1001)', () => {
-    const c = buildFeedPostActivity(
-      ctx,
-      { ...input, message: 'Lovely trail!', timeZone: 'Europe/Stockholm' },
-      () => undefined,
-    )
-    expect(c.object['aurboda:message']).toBe('Lovely trail!')
-    expect(c.object.content).toContain('<p>Lovely trail!</p>')
-    // 06:30Z is 08:30 in Stockholm (CEST) — the date line follows the author's tz.
-    expect(c.object.content).toContain('08:30')
-  })
-
-  test('omits aurboda:message when no message is set', () => {
-    const c = buildFeedPostActivity(ctx, input, () => undefined)
-    expect(c.object['aurboda:message']).toBeUndefined()
-  })
-})
+import { windowMetricStat } from './feed-activity.ts'
 
 const bucketed = (buckets: QueryMetricsBucketedResult['buckets']): QueryMetricsBucketedResult => ({
   bucket: '1h',

--- a/apps/backend/src/services/activitypub/feed-activity.ts
+++ b/apps/backend/src/services/activitypub/feed-activity.ts
@@ -1,59 +1,31 @@
 /**
- * Assemble the AS2 `Create{Exercise}` for a stored feed post.
+ * Resolve the shared scalar-summary values for a stored feed post.
  *
- * Bridges the persistence layer (`feed_posts` + `activities`) to the pure AS2
- * serializer: resolves the shared scalar values over the activity window and
- * builds the canonical federation URLs, then hands off to `buildCreateExercise`.
+ * Bridges the persistence layer (`feed_posts` + `activities`) to the pure
+ * scalar resolver: aggregates the source metrics over the activity window and
+ * maps the user's `included_metrics` selection into `ScalarMetric[]` for the
+ * delivery layer (`deliver.ts`).
  *
- * The metric aggregation is dependency-injected (`MetricStat`) so this is
- * unit-testable without a database; `windowMetricStat` adapts a
+ * The metric aggregation is dependency-injected (`MetricStat`) so the mapping
+ * is unit-testable without a database; `windowMetricStat` adapts a
  * `queryMetricsBucketed` result into that shape for the delivery path.
  */
-import { type FeedVisibility, hrZoneMetrics } from '@aurboda/api-spec'
+import { hrZoneMetrics } from '@aurboda/api-spec'
 
 import type { MetricType } from '../../schema.ts'
 import type { QueryMetricsBucketedResult } from '../queries/types.ts'
-import type { AS2Create, ScalarMetric } from './object.ts'
+import type { ScalarMetric } from './object.ts'
 import type { MetricStat, ScalarStat } from './scalars.ts'
 
 import { getTimeSeries } from '../../db/index.ts'
 import { queryMetricsBucketed } from '../queries/index.ts'
 import { computeHrZoneSecs, getEffectiveHrZones } from '../settings.ts'
-import { buildCreateExercise } from './object.ts'
 import { resolveSharedScalars, SCALAR_SOURCE_METRICS } from './scalars.ts'
 
 /** Maps `hr_zone_<n>_sec` → the numeric zone index (0–5) in `HrZoneSecs`. */
 const HR_ZONE_INDEX = new Map<string, 0 | 1 | 2 | 3 | 4 | 5>(
   hrZoneMetrics.map((m, i) => [m, i as 0 | 1 | 2 | 3 | 4 | 5]),
 )
-
-/** Canonical federation URLs for a user, derived from the deploy's public hosts. */
-export interface FeedActivityContext {
-  username: string
-  /** Canonical web origin, e.g. `https://aurboda.net` (actor, post id, aurboda: ns). */
-  origin: string
-  /** Public API base, e.g. `https://aurboda.net/api` (the public series endpoint). */
-  apiBaseUrl: string
-}
-
-export interface FeedActivityInput {
-  postId: string
-  includedMetrics: string[]
-  seriesMetrics: string[]
-  visibility: FeedVisibility
-  activityType: string
-  startTime: Date
-  endTime?: Date
-  title?: string
-  /** When the post was created (drives AS2 `published`). */
-  publishedAt: Date
-  /** The author's personal message for the post (plain text), if any. */
-  message?: string
-  /** IANA timezone the activity-date line renders in (the author's device timezone). */
-  timeZone?: string
-}
-
-const trimSlashes = (s: string): string => s.replace(/\/+$/, '')
 
 /**
  * Merge a bucketed-metrics result into a `MetricStat` over the whole window.
@@ -119,35 +91,4 @@ export const resolveActivityScalars = async (
   }
 
   return resolveSharedScalars({ endTime: activity.end_time, startTime: start }, includedMetrics, metricStat)
-}
-
-/** Build the `Create{Exercise}` activity for a feed post. */
-export const buildFeedPostActivity = (
-  ctx: FeedActivityContext,
-  input: FeedActivityInput,
-  metricStat: MetricStat,
-): AS2Create => {
-  const origin = trimSlashes(ctx.origin)
-  const actorUrl = `${origin}/users/${ctx.username}`
-  const scalars = resolveSharedScalars(
-    { endTime: input.endTime, startTime: input.startTime },
-    input.includedMetrics,
-    metricStat,
-  )
-  return buildCreateExercise({
-    activityType: input.activityType,
-    actorUrl,
-    aurbodaNs: `${origin}/ns/activitystreams#`,
-    endTime: input.endTime?.toISOString(),
-    message: input.message,
-    postId: `${actorUrl}/feed/${input.postId}`,
-    publishedAt: input.publishedAt.toISOString(),
-    scalars,
-    seriesEndpointBase: `${trimSlashes(ctx.apiBaseUrl)}/public/${ctx.username}/series`,
-    seriesMetrics: input.seriesMetrics,
-    startTime: input.startTime.toISOString(),
-    timeZone: input.timeZone,
-    title: input.title,
-    visibility: input.visibility,
-  })
 }

--- a/apps/backend/src/services/activitypub/object.test.ts
+++ b/apps/backend/src/services/activitypub/object.test.ts
@@ -1,31 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import {
-  addressingFor,
-  AS_PUBLIC,
-  type BuildCreateInput,
-  buildCreateExercise,
-  feedPostContent,
-  formatActivityWindow,
-} from './object.ts'
-
-const base: BuildCreateInput = {
-  activityType: 'running',
-  actorUrl: 'https://aurboda.net/u/fredrik',
-  aurbodaNs: 'https://aurboda.net/ns/activitystreams#',
-  endTime: '2026-07-01T07:11:03Z',
-  postId: 'https://aurboda.net/u/fredrik/feed/abc',
-  scalars: [
-    { key: 'distance', label: 'Distance', unit: 'km', value: 8.2 },
-    { key: 'heart_rate_avg', label: 'Avg HR', unit: 'bpm', value: 148 },
-    { key: 'hr_zone_minutes', value: { z2: 22, z3: 11 } },
-  ],
-  seriesEndpointBase: 'https://aurboda.net/api/public/fredrik/series',
-  seriesMetrics: ['heart_rate'],
-  startTime: '2026-07-01T06:30:00Z',
-  title: 'Morning run',
-  visibility: 'public',
-}
+import { addressingFor, AS_PUBLIC, feedPostContent, formatActivityWindow } from './object.ts'
 
 describe('addressingFor', () => {
   const followers = 'https://aurboda.net/u/fredrik/followers'
@@ -37,133 +12,6 @@ describe('addressingFor', () => {
   })
   test('followers → followers only, no Public anywhere', () => {
     expect(addressingFor('followers', followers)).toEqual({ cc: [], to: [followers] })
-  })
-})
-
-describe('buildCreateExercise', () => {
-  test('produces a Create with a Note-first dual type and canonical ids', () => {
-    const c = buildCreateExercise(base)
-    expect(c.type).toBe('Create')
-    expect(c.id).toBe('https://aurboda.net/u/fredrik/feed/abc')
-    expect(c.actor).toBe(base.actorUrl)
-    expect(c.published).toBe(base.startTime)
-    expect(c.to).toEqual([AS_PUBLIC])
-    expect(c.cc).toEqual(['https://aurboda.net/u/fredrik/followers'])
-    expect(c.object.id).toBe('https://aurboda.net/u/fredrik/feed/abc/object')
-    expect(c.object.type).toEqual(['Note', 'aurboda:Exercise'])
-    expect(c.object.attributedTo).toBe(base.actorUrl)
-    expect(c.object.url).toBe(base.postId)
-  })
-
-  test('@context maps the aurboda namespace prefix', () => {
-    const c = buildCreateExercise(base)
-    expect(c['@context']).toEqual([
-      'https://www.w3.org/ns/activitystreams',
-      { aurboda: 'https://aurboda.net/ns/activitystreams#' },
-    ])
-  })
-
-  test('content is a bold title headline, the activity-date line, and one stat per line', () => {
-    const c = buildCreateExercise(base)
-    expect(c.object.content).toBe(
-      '<p><strong>Morning run</strong></p>' +
-        '<p>Wed, 1 Jul 2026, 06:30–07:11</p>' +
-        '<p>Distance 8.2 km<br>Avg HR 148 bpm<br>Hr zone minutes z2 22, z3 11</p>',
-    )
-  })
-
-  test('a personal message renders between the headline and the date line, and rides aurboda:message', () => {
-    const c = buildCreateExercise({ ...base, message: 'Felt great,\nnegative splits!' })
-    expect(c.object.content).toBe(
-      '<p><strong>Morning run</strong></p>' +
-        '<p>Felt great,<br>negative splits!</p>' +
-        '<p>Wed, 1 Jul 2026, 06:30–07:11</p>' +
-        '<p>Distance 8.2 km<br>Avg HR 148 bpm<br>Hr zone minutes z2 22, z3 11</p>',
-    )
-    expect(c.object['aurboda:message']).toBe('Felt great,\nnegative splits!')
-  })
-
-  test('no aurboda:message and no message paragraph for a blank message', () => {
-    const c = buildCreateExercise({ ...base, message: '   ' })
-    expect(c.object['aurboda:message']).toBeUndefined()
-    expect(c.object.content).not.toContain('<p> ')
-  })
-
-  test('the date line renders in the given timezone', () => {
-    const c = buildCreateExercise({ ...base, timeZone: 'Europe/Stockholm' })
-    // 06:30Z–07:11Z is 08:30–09:11 CEST.
-    expect(c.object.content).toContain('<p>Wed, 1 Jul 2026, 08:30–09:11</p>')
-  })
-
-  test('aurboda:metrics carries the machine-readable shared scalars only', () => {
-    const c = buildCreateExercise(base)
-    expect(c.object['aurboda:metrics']).toEqual([
-      { key: 'distance', unit: 'km', value: 8.2 },
-      { key: 'heart_rate_avg', unit: 'bpm', value: 148 },
-      { key: 'hr_zone_minutes', value: { z2: 22, z3: 11 } },
-    ])
-  })
-
-  test('duration is computed from the window', () => {
-    const c = buildCreateExercise(base)
-    expect(c.object['aurboda:durationSeconds']).toBe(2463)
-    expect(c.object['aurboda:endTime']).toBe(base.endTime)
-  })
-
-  test('aurboda:series links only the explicitly-shared series metrics, scoped to the window', () => {
-    const c = buildCreateExercise(base)
-    expect(c.object['aurboda:series']).toEqual([
-      {
-        href: 'https://aurboda.net/api/public/fredrik/series?bucket=5s&end=2026-07-01T07%3A11%3A03Z&metric=heart_rate&start=2026-07-01T06%3A30%3A00Z',
-        mediaType: 'application/json',
-        metric: 'heart_rate',
-      },
-    ])
-  })
-
-  test('no series links when none were shared', () => {
-    const c = buildCreateExercise({ ...base, seriesMetrics: [] })
-    expect(c.object['aurboda:series']).toBeUndefined()
-  })
-
-  test('no series links for a followers-only post (public /series would 404)', () => {
-    const c = buildCreateExercise({ ...base, seriesMetrics: ['heart_rate'], visibility: 'followers' })
-    expect(c.object['aurboda:series']).toBeUndefined()
-    // The scalar summary still rides along for followers.
-    expect(c.object['aurboda:metrics']).toHaveLength(base.scalars.length)
-  })
-
-  test('no series links or duration for an open-ended activity (no end time)', () => {
-    const c = buildCreateExercise({ ...base, endTime: undefined })
-    expect(c.object['aurboda:series']).toBeUndefined()
-    expect(c.object['aurboda:durationSeconds']).toBeUndefined()
-    expect(c.object['aurboda:endTime']).toBeUndefined()
-  })
-
-  test('escapes HTML in the title for the fallback content', () => {
-    const c = buildCreateExercise({ ...base, scalars: [], title: 'Run <b>x</b> & "go"' })
-    expect(c.object.content).toBe(
-      '<p><strong>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</strong></p>' +
-        '<p>Wed, 1 Jul 2026, 06:30–07:11</p>',
-    )
-  })
-
-  test('uses publishedAt for the AS2 published times, keeping the workout time in aurboda:startTime', () => {
-    const c = buildCreateExercise({ ...base, publishedAt: '2026-07-01T20:00:00Z' })
-    expect(c.published).toBe('2026-07-01T20:00:00Z')
-    expect(c.object.published).toBe('2026-07-01T20:00:00Z')
-    expect(c.object['aurboda:startTime']).toBe(base.startTime)
-  })
-
-  test('published defaults to startTime when publishedAt is omitted', () => {
-    const c = buildCreateExercise(base)
-    expect(c.published).toBe(base.startTime)
-    expect(c.object.published).toBe(base.startTime)
-  })
-
-  test('falls back to a derived name when the activity has no title', () => {
-    const c = buildCreateExercise({ ...base, title: undefined })
-    expect(c.object.name).toBe('Running activity')
   })
 })
 
@@ -203,6 +51,26 @@ describe('feedPostContent', () => {
     )
   })
 
+  test('a personal message renders between the headline and the date line', () => {
+    const { content } = feedPostContent(
+      'Morning run',
+      'running',
+      [{ key: 'distance', label: 'Distance', unit: 'km', value: 8.2 }],
+      { message: 'Felt great,\nnegative splits!', windowLabel: 'Wed, 1 Jul 2026, 06:30–07:11' },
+    )
+    expect(content).toBe(
+      '<p><strong>Morning run</strong></p>' +
+        '<p>Felt great,<br>negative splits!</p>' +
+        '<p>Wed, 1 Jul 2026, 06:30–07:11</p>' +
+        '<p>Distance 8.2 km</p>',
+    )
+  })
+
+  test('a blank message renders no message paragraph', () => {
+    const { content } = feedPostContent('Row', 'rowing', [], { message: '   ' })
+    expect(content).toBe('<p><strong>Row</strong></p>')
+  })
+
   test('escapes HTML in the message and preserves its linebreaks as <br>', () => {
     const { content } = feedPostContent('Row', 'rowing', [], {
       message: 'So <b>good</b>\n& calm',
@@ -213,6 +81,11 @@ describe('feedPostContent', () => {
         '<p>So &lt;b&gt;good&lt;/b&gt;<br>&amp; calm</p>' +
         '<p>Sun, 2 Aug 2026, 15:44–18:12</p>',
     )
+  })
+
+  test('escapes HTML in the title for the fallback content', () => {
+    const { content } = feedPostContent('Run <b>x</b> & "go"', 'running', [])
+    expect(content).toBe('<p><strong>Run &lt;b&gt;x&lt;/b&gt; &amp; &quot;go&quot;</strong></p>')
   })
 
   test('renders hours and minutes for a long duration', () => {

--- a/apps/backend/src/services/activitypub/object.ts
+++ b/apps/backend/src/services/activitypub/object.ts
@@ -1,19 +1,12 @@
 /**
- * AS2 object model for a shared activity.
+ * Pure AS2 building blocks shared by the delivery layer (`deliver.ts`) and the
+ * public feed surfaces: visibility→addressing, the human-readable Note content
+ * (`feedPostContent`), and the activity-date line. All pure functions of their
+ * inputs, so fully unit-testable with no Fedify dependency.
  *
- * Serializes a feed post into a `Create` activity whose `object` is a dual-typed
- * `["Note", "aurboda:Exercise"]`: `Note` first so plain fediverse clients
- * (Mastodon) render `name`/`content`/`url` as a status, plus structured
- * `aurboda:` extension fields that an Aurboda↔Aurboda consumer reads
- * ("progressive enhancement").
- *
- * This module is a pure function of its inputs — the caller resolves the shared
- * scalar values and passes in the absolute URLs — so it is fully unit-testable
- * and carries no dependency on the (upcoming) Fedify actor/delivery layer. Only
- * the metrics the user actually shared are ever emitted: unshared scalars are
- * absent from `content` and `aurboda:metrics`, and only `seriesMetrics` on a
- * `public`/`unlisted` post produce `aurboda:series` links (matching what the
- * public `/series` endpoint will actually resolve).
+ * The structured extension a QuantPub peer reads (`["Note", "quant:Exercise"]`
+ * dual-typing, `quant:metrics`, `quant:series`) lives in `quant-extension.ts`
+ * and is spliced into the delivered/served JSON-LD there (#896).
  */
 
 import type { FeedVisibility } from '@aurboda/api-spec'
@@ -31,51 +24,6 @@ export interface ScalarMetric {
   unit?: string
   /** Optional human label for the fallback text; defaults to a prettified key. */
   label?: string
-}
-
-export interface BuildCreateInput {
-  /** Canonical absolute URL of the post (the `Create` activity `id`). */
-  postId: string
-  /** Absolute actor URL (e.g. `https://host/u/fredrik`). */
-  actorUrl: string
-  /** The `aurboda:` term prefix IRI, ending in `#` (e.g. `https://host/ns/activitystreams#`). */
-  aurbodaNs: string
-  /** Base URL of the public series endpoint (e.g. `https://host/api/public/fredrik/series`). */
-  seriesEndpointBase: string
-  visibility: FeedVisibility
-  activityType: string
-  /** Activity start (ISO 8601); the workout time, kept in `aurboda:startTime`. */
-  startTime: string
-  /** Activity end (ISO 8601); required for duration and series links. */
-  endTime?: string
-  /**
-   * When the post was created (ISO 8601), used for the AS2 `published` of the
-   * Create and its object so remote timelines order it by share time, not the
-   * (possibly much earlier) workout time. Defaults to `startTime`.
-   */
-  publishedAt?: string
-  title?: string
-  /** The author's personal message for the post (plain text), if any. */
-  message?: string
-  /** IANA timezone for the human-readable activity-date line (defaults to UTC). */
-  timeZone?: string
-  /** Resolved scalar summaries for the shared `included_metrics`. */
-  scalars: ScalarMetric[]
-  /** Metric keys whose series were explicitly shared (drive `aurboda:series`). */
-  seriesMetrics: string[]
-  /** Bucket granularity for the series links (defaults to `5s`). */
-  seriesBucket?: string
-}
-
-export interface AS2Create {
-  '@context': [string, Record<string, string>]
-  id: string
-  type: 'Create'
-  actor: string
-  published: string
-  to: string[]
-  cc: string[]
-  object: Record<string, unknown>
 }
 
 const escapeHtml = (s: string): string =>
@@ -216,90 +164,5 @@ export const addressingFor = (
       return { cc: [AS_PUBLIC], to: [followersUrl] }
     case 'followers':
       return { cc: [], to: [followersUrl] }
-  }
-}
-
-/**
- * Build the `aurboda:series` link objects for the shared series metrics.
- *
- * Emitted only for `public`/`unlisted` posts: the public `/series` endpoint
- * refuses `followers`-only posts, so advertising links there would just 404.
- * Series also need a bounded activity window.
- */
-const seriesLinks = (input: BuildCreateInput): Record<string, string>[] => {
-  const { endTime, seriesMetrics, visibility } = input
-  if (visibility === 'followers' || !endTime || seriesMetrics.length === 0) return []
-  const bucket = input.seriesBucket ?? '5s'
-  return seriesMetrics.map((metric) => {
-    const params = new URLSearchParams({
-      bucket,
-      end: endTime,
-      metric,
-      start: input.startTime,
-    })
-    return {
-      href: `${input.seriesEndpointBase}?${params.toString()}`,
-      mediaType: 'application/json',
-      metric,
-    }
-  })
-}
-
-/**
- * Build a `Create{Exercise}` AS2 activity for a shared post. Pure and
- * deterministic given its inputs.
- */
-export const buildCreateExercise = (input: BuildCreateInput): AS2Create => {
-  const followersUrl = `${input.actorUrl}/followers`
-  const { to, cc } = addressingFor(input.visibility, followersUrl)
-  const objectId = `${input.postId}/object`
-
-  const { content, name } = feedPostContent(input.title, input.activityType, input.scalars, {
-    message: input.message,
-    windowLabel: formatActivityWindow(input.startTime, input.endTime, input.timeZone),
-  })
-  // `published` is the share time (timeline ordering); the workout time lives in
-  // `aurboda:startTime`.
-  const published = input.publishedAt ?? input.startTime
-
-  const object: Record<string, unknown> = {
-    'aurboda:activityType': input.activityType,
-    'aurboda:metrics': input.scalars.map(({ key, unit, value }) => ({
-      key,
-      ...(unit === undefined ? {} : { unit }),
-      value,
-    })),
-    'aurboda:startTime': input.startTime,
-    attributedTo: input.actorUrl,
-    content,
-    id: objectId,
-    name,
-    published,
-    // Note first → Mastodon uses content/name/url; Aurboda recognises aurboda:Exercise.
-    type: ['Note', 'aurboda:Exercise'],
-    url: input.postId,
-  }
-
-  if (input.message !== undefined && input.message.trim() !== '') {
-    object['aurboda:message'] = input.message
-  }
-  if (input.endTime) {
-    object['aurboda:endTime'] = input.endTime
-    object['aurboda:durationSeconds'] = Math.round(
-      (new Date(input.endTime).getTime() - new Date(input.startTime).getTime()) / 1000,
-    )
-  }
-  const series = seriesLinks(input)
-  if (series.length > 0) object['aurboda:series'] = series
-
-  return {
-    '@context': ['https://www.w3.org/ns/activitystreams', { aurboda: input.aurbodaNs }],
-    actor: input.actorUrl,
-    cc,
-    id: input.postId,
-    object,
-    published,
-    to,
-    type: 'Create',
   }
 }

--- a/apps/backend/src/services/activitypub/quant-extension.test.ts
+++ b/apps/backend/src/services/activitypub/quant-extension.test.ts
@@ -1,0 +1,165 @@
+import { Note } from '@fedify/fedify/vocab'
+import { describe, expect, test } from 'vitest'
+
+import type { QuantExerciseInput } from './quant-extension.ts'
+
+import {
+  quantContextDocument,
+  quantContextEntry,
+  quantExerciseExtension,
+  spliceQuantExtension,
+  withQuantJsonLd,
+} from './quant-extension.ts'
+
+const base: QuantExerciseInput = {
+  activityType: 'running',
+  apiBaseUrl: 'https://aurboda.net/api/',
+  endTime: new Date('2026-07-01T07:11:03Z'),
+  imageToken: 'secret-token',
+  postId: 'abc123',
+  scalars: [
+    { key: 'distance', label: 'Distance', unit: 'km', value: 8.2 },
+    { key: 'hr_zone_minutes', value: { z2: 22, z3: 11 } },
+  ],
+  seriesMetrics: ['heart_rate'],
+  startTime: new Date('2026-07-01T06:30:00Z'),
+  user: 'fiddur',
+  visibility: 'public',
+}
+
+describe('quantExerciseExtension', () => {
+  test('carries the activity type and the machine-readable shared scalars only', () => {
+    const props = quantExerciseExtension(base)
+    expect(props['quant:activityType']).toBe('running')
+    // Labels are content-only; a unit-less scalar omits the unit key entirely.
+    expect(props['quant:metrics']).toEqual([
+      { key: 'distance', unit: 'km', value: 8.2 },
+      { key: 'hr_zone_minutes', value: { z2: 22, z3: 11 } },
+    ])
+  })
+
+  test('links the structured payload without a token on a public post', () => {
+    const props = quantExerciseExtension(base)
+    expect(props['quant:structuredUrl']).toBe('https://aurboda.net/api/public/fiddur/feed/abc123')
+  })
+
+  test('a followers-only post carries the capability token on the structured URL (FEP §9)', () => {
+    const props = quantExerciseExtension({ ...base, visibility: 'followers' })
+    expect(props['quant:structuredUrl']).toBe(
+      'https://aurboda.net/api/public/fiddur/feed/abc123?token=secret-token',
+    )
+  })
+
+  test('series links only the explicitly-shared series metrics, scoped to the window', () => {
+    const props = quantExerciseExtension(base)
+    expect(props['quant:series']).toEqual([
+      {
+        href: 'https://aurboda.net/api/public/fiddur/series?bucket=5s&end=2026-07-01T07%3A11%3A03.000Z&metric=heart_rate&start=2026-07-01T06%3A30%3A00.000Z',
+        mediaType: 'application/json',
+        metric: 'heart_rate',
+      },
+    ])
+  })
+
+  test('no series links when none were shared', () => {
+    expect(quantExerciseExtension({ ...base, seriesMetrics: [] })['quant:series']).toBeUndefined()
+  })
+
+  test('no series links for a followers-only post (public /series would 404)', () => {
+    const props = quantExerciseExtension({ ...base, visibility: 'followers' })
+    expect(props['quant:series']).toBeUndefined()
+    // The scalar summary still rides along for followers.
+    expect(props['quant:metrics']).toHaveLength(base.scalars.length)
+  })
+
+  test('no series links for an open-ended activity (no end time)', () => {
+    expect(quantExerciseExtension({ ...base, endTime: undefined })['quant:series']).toBeUndefined()
+  })
+})
+
+describe('spliceQuantExtension', () => {
+  const props = { 'quant:activityType': 'running' }
+
+  test('splices a bare object document: dual type, props, extended @context', () => {
+    const doc = {
+      '@context': ['https://www.w3.org/ns/activitystreams'],
+      content: '<p>x</p>',
+      type: 'Note',
+    }
+    expect(spliceQuantExtension(doc, props)).toEqual({
+      '@context': ['https://www.w3.org/ns/activitystreams', quantContextEntry],
+      content: '<p>x</p>',
+      'quant:activityType': 'running',
+      type: ['Note', 'quant:Exercise'],
+    })
+  })
+
+  test('wraps a plain string @context into an array with the quant entry', () => {
+    const out = spliceQuantExtension(
+      { '@context': 'https://www.w3.org/ns/activitystreams', type: 'Note' },
+      props,
+    )
+    expect(out).toMatchObject({
+      '@context': ['https://www.w3.org/ns/activitystreams', quantContextEntry],
+    })
+  })
+
+  test('splices an activity document into its embedded object, extending both contexts', () => {
+    const doc = {
+      '@context': ['https://www.w3.org/ns/activitystreams'],
+      object: {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        content: '<p>x</p>',
+        type: 'Note',
+      },
+      type: 'Create',
+    }
+    const out = spliceQuantExtension(doc, props)
+    expect(out).toEqual({
+      '@context': ['https://www.w3.org/ns/activitystreams', quantContextEntry],
+      object: {
+        '@context': ['https://www.w3.org/ns/activitystreams', quantContextEntry],
+        content: '<p>x</p>',
+        'quant:activityType': 'running',
+        type: ['Note', 'quant:Exercise'],
+      },
+      type: 'Create',
+    })
+  })
+
+  test('is idempotent on the type (never doubles quant:Exercise)', () => {
+    const once = spliceQuantExtension({ type: ['Note', 'quant:Exercise'] }, props)
+    expect(once).toMatchObject({ type: ['Note', 'quant:Exercise'] })
+  })
+
+  test('passes a non-record document through untouched', () => {
+    expect(spliceQuantExtension('x', props)).toBe('x')
+    expect(spliceQuantExtension(null, props)).toBe(null)
+  })
+})
+
+describe('withQuantJsonLd', () => {
+  test('a wrapped Note serializes with the extension and the quant @context entry', async () => {
+    const note = new Note({
+      content: '<p><strong>Morning run</strong></p>',
+      id: new URL('https://aurboda.net/users/fiddur/feed/abc123'),
+      name: 'Morning run',
+    })
+    const wrapped = withQuantJsonLd(note, quantExerciseExtension(base))
+    const doc = await wrapped.toJsonLd()
+    expect(doc).toMatchObject({
+      id: 'https://aurboda.net/users/fiddur/feed/abc123',
+      'quant:activityType': 'running',
+      'quant:structuredUrl': 'https://aurboda.net/api/public/fiddur/feed/abc123',
+      type: ['Note', 'quant:Exercise'],
+    })
+    if (typeof doc !== 'object' || doc === null || !('@context' in doc)) throw new Error('no @context')
+    expect(doc['@context']).toContainEqual(quantContextEntry)
+  })
+})
+
+describe('quantContextDocument', () => {
+  test('the published context is exactly the inline entry', () => {
+    expect(quantContextDocument).toEqual({ '@context': quantContextEntry })
+  })
+})

--- a/apps/backend/src/services/activitypub/quant-extension.ts
+++ b/apps/backend/src/services/activitypub/quant-extension.ts
@@ -1,0 +1,164 @@
+/**
+ * QuantPub (`quant:`) JSON-LD extension for federated exercise shares (#896).
+ *
+ * Implements the vocabulary from `docs/fep/quantpub.md` on the wire: a shared
+ * activity's Note is dual-typed `["Note", "quant:Exercise"]` and carries the
+ * typed extension properties (`quant:activityType`, `quant:metrics`,
+ * `quant:series`, `quant:structuredUrl`) so a QuantPub peer reads structured
+ * data in-band while Mastodon still renders the plain Note. The AS2 window
+ * (`startTime`/`endTime`) is set natively on the Fedify `Note` (the FEP reuses
+ * AS2's own terms), so only the `quant:` terms need this module.
+ *
+ * Fedify's generated vocabulary drops unknown properties, so the extension is
+ * spliced into the **serialized JSON-LD** instead: `withQuantJsonLd` wraps one
+ * locally-built instance's `toJsonLd` and post-processes its final document —
+ * after all of Fedify's own JSON-LD compaction — adding the properties, the
+ * dual type, and the inline `@context` term definitions (`quant:metrics` and
+ * `quant:series` are `@json` literals per FEP §1, so JSON-LD processors keep
+ * their nested objects verbatim). Wrap only the OUTERMOST object handed to
+ * Fedify (the bare `Note` for the object dispatcher; the `Create`/`Update` for
+ * delivery and the outbox): an embedded child's splice would be re-compacted
+ * against the parent's context and mangled into expanded-IRI form.
+ *
+ * Caveat: the wrapper is an instance patch, so anything that CLONES the object
+ * afterwards (e.g. Fedify's Ed25519 `signObject`, unused here — Aurboda only
+ * provisions RSA keys) would silently drop the extension. The RSA Linked-Data
+ * signature and HTTP signatures both operate on the spliced document, so they
+ * stay valid.
+ */
+import type { FeedVisibility } from '@aurboda/api-spec'
+import type { Object as APObject } from '@fedify/fedify/vocab'
+
+import type { ScalarMetric } from './object.ts'
+
+import { isPubliclyVisible } from './object.ts'
+
+/** The QuantPub JSON-LD namespace (FEP §1; final IRI settles with the FEP number). */
+export const QUANT_NS = 'https://w3id.org/quantpub#'
+
+/** The QuantPub spec version this implementation speaks (discovery document §4). */
+export const QUANTPUB_VERSION = '0.1'
+
+/**
+ * The inline `@context` entry defining the `quant:` prefix. `quant:metrics` and
+ * `quant:series` are JSON literals (`@json`) so conforming processors preserve
+ * their nested `key`/`value`/`unit` and `metric`/`mediaType`/`href` objects
+ * verbatim instead of expanding (and losing) unmapped keys.
+ */
+export const quantContextEntry: Record<string, unknown> = {
+  quant: QUANT_NS,
+  'quant:metrics': { '@type': '@json' },
+  'quant:series': { '@type': '@json' },
+}
+
+/**
+ * The published JSON-LD `@context` document (served at `/ns/quantpub`), the
+ * canonical form of the inline entry every delivered object also embeds.
+ */
+export const quantContextDocument: Record<string, unknown> = { '@context': quantContextEntry }
+
+export interface QuantExerciseInput {
+  /** Public API base, e.g. `https://aurboda.net/api` (structured + series URLs hang off it). */
+  apiBaseUrl: string
+  user: string
+  postId: string
+  /** Capability token appended for `followers`-only posts (FEP §9). */
+  imageToken: string
+  visibility: FeedVisibility
+  activityType: string
+  startTime: Date
+  endTime?: Date
+  /** Resolved scalar summaries for the shared `included_metrics`. */
+  scalars: ScalarMetric[]
+  /** Metric keys whose series were explicitly shared (drive `quant:series`). */
+  seriesMetrics: string[]
+  /** Bucket granularity for the series links (defaults to `5s`). */
+  seriesBucket?: string
+}
+
+/**
+ * Build the `quant:` extension properties for one shared activity (FEP §2).
+ *
+ * `quant:series` links are emitted only for `public`/`unlisted` posts with a
+ * bounded window: the public series endpoint refuses `followers`-only posts,
+ * so advertising links there would just 404. `quant:structuredUrl` carries the
+ * capability token for `followers`-only posts (FEP §9 allows it — the token is
+ * already in the delivered image attachment URLs, never on a public surface).
+ */
+export const quantExerciseExtension = (input: QuantExerciseInput): Record<string, unknown> => {
+  const publicBase = `${input.apiBaseUrl.replace(/\/+$/, '')}/public/${encodeURIComponent(input.user)}`
+  const token = isPubliclyVisible(input.visibility) ? '' : `?token=${encodeURIComponent(input.imageToken)}`
+  const props: Record<string, unknown> = {
+    'quant:activityType': input.activityType,
+    'quant:metrics': input.scalars.map(({ key, unit, value }) => ({
+      key,
+      ...(unit === undefined ? {} : { unit }),
+      value,
+    })),
+    'quant:structuredUrl': `${publicBase}/feed/${input.postId}${token}`,
+  }
+  const endTime = input.endTime
+  if (isPubliclyVisible(input.visibility) && endTime !== undefined && input.seriesMetrics.length > 0) {
+    const bucket = input.seriesBucket ?? '5s'
+    props['quant:series'] = input.seriesMetrics.map((metric) => {
+      const params = new URLSearchParams({
+        bucket,
+        end: endTime.toISOString(),
+        metric,
+        start: input.startTime.toISOString(),
+      })
+      return { href: `${publicBase}/series?${params.toString()}`, mediaType: 'application/json', metric }
+    })
+  }
+  return props
+}
+
+type JsonRecord = Record<string, unknown>
+
+const isRecord = (v: unknown): v is JsonRecord => typeof v === 'object' && v !== null && !Array.isArray(v)
+
+/** Dual-type a serialized `type` value with `quant:Exercise` (idempotent). */
+const withQuantType = (type: unknown): unknown => {
+  if (typeof type === 'string') return type === 'quant:Exercise' ? type : [type, 'quant:Exercise']
+  if (Array.isArray(type)) return type.includes('quant:Exercise') ? type : [...type, 'quant:Exercise']
+  return type
+}
+
+/** Append the `quant:` term definitions to a serialized `@context` value. */
+const withQuantContext = (context: unknown): unknown => {
+  if (context === undefined || context === null) {
+    return ['https://www.w3.org/ns/activitystreams', quantContextEntry]
+  }
+  return Array.isArray(context) ? [...context, quantContextEntry] : [context, quantContextEntry]
+}
+
+/**
+ * Splice the extension into a final serialized document: onto the embedded
+ * `object` when the document is an activity (`Create`/`Update`), else onto the
+ * document itself, extending each `@context` in scope. Non-object documents
+ * pass through untouched — enrichment must never break serialization.
+ */
+export const spliceQuantExtension = (doc: unknown, props: JsonRecord): unknown => {
+  if (!isRecord(doc)) return doc
+  const embedded = isRecord(doc.object) ? doc.object : undefined
+  const target = embedded ?? doc
+  const enriched: JsonRecord = { ...target, ...props, type: withQuantType(target.type) }
+  // An embedded object serialized with its own scoped @context keeps it valid standalone.
+  if (embedded !== undefined && '@context' in enriched) {
+    enriched['@context'] = withQuantContext(enriched['@context'])
+  }
+  const out: JsonRecord = embedded === undefined ? enriched : { ...doc, object: enriched }
+  return { ...out, '@context': withQuantContext(out['@context']) }
+}
+
+/**
+ * Wrap a locally-built Fedify object so its serialized JSON-LD carries the
+ * `quant:` extension. Returns the same instance, with `toJsonLd` patched to
+ * post-process its own output.
+ */
+export const withQuantJsonLd = <T extends APObject>(obj: T, props: JsonRecord): T => {
+  const base = obj.toJsonLd.bind(obj)
+  obj.toJsonLd = async (options?: Parameters<APObject['toJsonLd']>[0]): Promise<unknown> =>
+    spliceQuantExtension(await base(options), props)
+  return obj
+}

--- a/apps/backend/src/services/activitypub/scalars.ts
+++ b/apps/backend/src/services/activitypub/scalars.ts
@@ -2,7 +2,7 @@
  * Resolve the shared scalar-summary values for a feed post.
  *
  * Turns the user's chosen `included_metrics` keys into the `ScalarMetric[]` that
- * `buildCreateExercise` renders into `content` and `aurboda:metrics`. Pure and
+ * the delivery layer renders into `content` and `quant:metrics`. Pure and
  * dependency-injected: the caller supplies `metricStat`, an aggregate of a
  * metric over the shared activity's window (backed by `queryMetricsBucketed`
  * with a single window-sized bucket when wired to delivery). Only the requested

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -147,8 +147,24 @@ happened (rendered in the author's device timezone, since AS2 `published` stays 
 share time for timeline ordering), and the shared scalar summaries one per line —
 plus a `name` headline, addressed per the post's visibility
 (`public` → AS2 Public + followers; `unlisted` → followers + Public in `cc`; `followers`
-→ followers only). The custom structured `aurboda:` extension (typed metrics + series
-links) is a separate, richer representation for Aurboda-to-Aurboda consumers.
+→ followers only).
+
+**QuantPub extension (#896).** An activity share's `Note` is dual-typed
+`["Note", "quant:Exercise"]` and carries the typed [QuantPub](../fep/quantpub.md)
+extension in-band: the AS2 window as native `startTime`/`endTime`, plus
+`quant:activityType`, `quant:metrics` (the shared scalar summaries as
+`key`/`value`/`unit` objects), `quant:series` links into the public series endpoint
+(only for `public`/`unlisted` posts with a bounded window), and
+`quant:structuredUrl` pointing at the structured post endpoint (carrying the
+capability token on `followers`-only deliveries). The `quant:` term definitions are
+embedded as an inline `@context` entry on every delivered/served document
+(`quant:metrics`/`quant:series` are JSON literals, `"@type": "@json"`), and the
+canonical context document is served at `GET /ns/quantpub`
+(`application/ld+json`); `GET /.well-known/quantpub` is the FEP §4 discovery
+document. Fedify's typed vocabulary drops unknown properties, so the extension is
+spliced into the serialized JSON-LD of the outermost delivered/served object
+(`services/activitypub/quant-extension.ts`); plain fediverse clients ignore the
+extra type and terms and render the Note as before.
 
 **Merged activities.** A post stores only `activity_id` (the plain anchor uuid). When that
 activity is part of a **merge group** (overlapping cross-source records, shown in the
@@ -292,11 +308,11 @@ timeline on the next load, in their published order.
 
 ### Native charts from Aurboda peers (structured enrichment)
 
-A delivered `Note` carries only the Mastodon-compatible HTML — Fedify's typed vocab drops the
-`aurboda:` extension, so the structured metrics/series don't survive federation on the object
-itself. To render a **native interactive chart** (with real, hoverable values) instead of the
-plain HTML when a post comes from **another Aurboda instance**, the receiver fetches the
-structured data out-of-band on ingest:
+A delivered `Note` carries the QuantPub scalar summary in-band (see above), but not the
+high-resolution series data itself. To render a **native interactive chart** (with real,
+hoverable values) instead of the plain HTML when a post comes from **another Aurboda
+instance**, the receiver fetches the structured data out-of-band on ingest (the FEP §7
+id-convention path — reliable even when a typed consumer drops the in-band extension):
 
 1. **Emit.** Every instance serves `GET /public/:username/feed/:postId` — a native JSON payload
    (`FeedStructuredPost`: a discriminated union on `kind`). An **activity** post resolves to
@@ -579,6 +595,8 @@ Public / federation (unauthenticated):
 | `GET /public/:username/feed/:postId/blocks/:index/image.svg` | Same article block as crisp `image/svg+xml`                                                                |
 | `GET /public/:username/posts`                                | A user's public/unlisted posts (newest-first, latest page) for their profile feed                          |
 | `GET /.well-known/webfinger`                                 | Resolve `acct:<username>@<host>` → the actor                                                               |
+| `GET /.well-known/quantpub`                                  | QuantPub discovery document (FEP §4): product, versions, `api_base`                                        |
+| `GET /ns/quantpub`                                           | The published QuantPub JSON-LD `@context` document (`application/ld+json`)                                 |
 | `GET /users/:username`                                       | The actor document (`Person`)                                                                              |
 | `GET /users/:username/outbox`                                | Public + unlisted posts as `Create` activities                                                             |
 | `GET /users/:username/followers`                             | The actor's followers collection                                                                           |
@@ -641,10 +659,11 @@ These are known and intentional for the current implementation:
 - **The public series endpoint uses the anchor window for merged shares.** The delivered
   Note's scalar summary and the rendered images cover the full merged span, but
   `GET /public/:username/series` still authorizes only the shared activity's _own_ window
-  (`findCoveringSharedSeriesWindow` joins on `activity_id`). Since the delivered
-  Mastodon `Note` carries no series links, this is latent — expanding series
-  authorization across a merge group (which needs the merge algorithm at query time) is a
-  planned follow-up.
+  (`findCoveringSharedSeriesWindow` joins on `activity_id`). The delivered Note's
+  `quant:series` links are built over the merged span, so for a **merged** share with
+  shared series those links can 404 until series authorization expands across a merge
+  group (which needs the merge algorithm at query time — a planned follow-up); QuantPub
+  consumers treat a failed series fetch as best-effort, so the post still renders.
 - **Route maps have no privacy trimming.** The route is drawn over an OpenStreetMap
   basemap and shows the full track, so a public route map reveals the precise area
   (including start/end points, i.e. likely home/work); start-point and area masking are

--- a/docs/fep/quantpub.md
+++ b/docs/fep/quantpub.md
@@ -538,23 +538,23 @@ GET /api/public/freja/series?metric=stress&start=...&end=...&bucket=60s
 
 ## Implementations
 
-- **[Aurboda](https://github.com/fiddur/aurboda)** — ships the whole pattern
-  today with vendor-prefixed names: an `aurboda:` typed extension
-  (`aurboda:Exercise`), `/.well-known/aurboda` discovery, the structured post
-  endpoint (activity and article kinds), the data-driven public series
-  endpoint, capability tokens for followers-only payloads, and Level 3
-  ingest/enrichment between Aurboda instances. This FEP generalises that
-  running code — including the §9 token lift from delivered attachment URLs
-  (`capabilityTokenFrom` in its enrichment path). Adopting it in Aurboda is
-  more than a prefix swap: the shipped extension mints its own window terms
-  (`aurboda:startTime` / `aurboda:endTime` / `aurboda:durationSeconds`) where
-  this document reuses AS2 `startTime`/`endTime` and folds duration into
-  `quant:metrics`; and while Aurboda's *delivery* path already matches the §7
-  id convention (the delivered `Note`'s id is the resolvable post URL, with
-  the `Create` as a `#create` fragment), its unused AS2 object-model builder
-  inverts that shape (activity at the post URL, object at `…/object`) and
-  would need aligning. Aurboda intends to adopt the `quant:` vocabulary,
-  including those substitutions, once it settles.
+- **[Aurboda](https://github.com/fiddur/aurboda)** — ships this document's
+  vocabulary on the wire: delivered exercise shares are dual-typed
+  `["Note", "quant:Exercise"]` with AS2 `startTime`/`endTime`,
+  `quant:activityType`, `quant:metrics`, `quant:series`, and
+  `quant:structuredUrl` (inline `@context` term definitions on every
+  delivered/served object), serves the `/.well-known/quantpub` discovery
+  document (§4) and a published context document at `/ns/quantpub`, the
+  structured post endpoint (activity and article kinds), the data-driven
+  public series endpoint, capability tokens for followers-only payloads, and
+  Level 3 ingest/enrichment between Aurboda instances via the §7 id
+  convention. This FEP generalises that running code — including the §9 token
+  lift from delivered attachment URLs (`capabilityTokenFrom` in its
+  enrichment path). Its delivery path matches §7's id convention: the
+  delivered `Note`'s id is the resolvable post URL, with the `Create` as a
+  `#create` fragment. (Remaining vendor-prefixed surface: the
+  `/.well-known/aurboda` document backs Aurboda-specific challenge
+  federation, alongside — not instead of — `/.well-known/quantpub`.)
 
 ## Copyright
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -71,6 +71,26 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # QuantPub federation discovery (FEP §4)
+    location = /.well-known/quantpub {
+        proxy_pass http://127.0.0.1:3000/.well-known/quantpub;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # QuantPub JSON-LD @context document (FEP §1)
+    location = /ns/quantpub {
+        proxy_pass http://127.0.0.1:3000/ns/quantpub;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ActivityPub WebFinger discovery (acct:<user>@<host> -> actor)
     location = /.well-known/webfinger {
         proxy_pass http://127.0.0.1:3000/.well-known/webfinger;

--- a/packages/api-spec/src/openapi.ts
+++ b/packages/api-spec/src/openapi.ts
@@ -17,6 +17,7 @@ import {
   challengesResponseSchema,
   challengeStandingsResponseSchema,
   wellKnownAurbodaSchema,
+  wellKnownQuantpubSchema,
 } from './schemas/challenges.ts'
 // Import all schemas
 import { dateOnlySchema, iso8601DateTimeSchema, metricTypeSchema } from './schemas/common.ts'
@@ -93,7 +94,7 @@ const openApiDocument = createDocument({
     // Served at the instance root (`/.well-known/aurboda`), outside the `/api`
     // server base, so it has no path entry — the model is registered so federation
     // clients (the Android challenge widget) get a generated type for it.
-    schemas: { WellKnownAurboda: wellKnownAurbodaSchema },
+    schemas: { WellKnownAurboda: wellKnownAurbodaSchema, WellKnownQuantpub: wellKnownQuantpubSchema },
     securitySchemes: {
       bearerAuth: {
         bearerFormat: 'JWT',

--- a/packages/api-spec/src/schemas/challenges.ts
+++ b/packages/api-spec/src/schemas/challenges.ts
@@ -324,3 +324,17 @@ export const wellKnownAurbodaSchema = z
   .meta({ id: 'WellKnownAurboda' })
 
 export type WellKnownAurboda = z.infer<typeof wellKnownAurbodaSchema>
+
+/** QuantPub discovery document (FEP §4, `/.well-known/quantpub`). */
+export const wellKnownQuantpubSchema = z
+  .object({
+    api_base: z
+      .string()
+      .meta({ description: 'Absolute base URL under which the structured-post and series endpoints live' }),
+    product: z.string().meta({ description: 'Free-form implementation identity' }),
+    quantpub: z.string().meta({ description: 'QuantPub spec version implemented' }),
+    version: z.string().meta({ description: 'Implementation build/version identifier' }),
+  })
+  .meta({ id: 'WellKnownQuantpub' })
+
+export type WellKnownQuantpub = z.infer<typeof wellKnownQuantpubSchema>


### PR DESCRIPTION
Closes #896.

Implements the remaining #831-scope federation item, aligned with the QuantPub FEP (`docs/fep/quantpub.md`) rather than the issue's original `aurboda:` naming — the FEP superseded it and states Aurboda intends to adopt `quant:`.

## What
- **Dual-typed delivery**: every activity share's Note — delivered `Create`/`Update`, outbox listing, and the dereferenceable object — is `["Note", "quant:Exercise"]` with:
  - native AS2 `startTime`/`endTime` (the FEP reuses AS2's own window terms),
  - `quant:activityType`, `quant:metrics` (shared scalars as `key`/`value`/`unit`),
  - `quant:series` links (public/unlisted + bounded window only — the public `/series` endpoint would 404 anything else),
  - `quant:structuredUrl` (carries the capability token on followers-only deliveries, FEP §9),
  - inline `@context` entry defining `quant:` with `@json`-literal terms.
- **New endpoints** (+ nginx routes): `GET /.well-known/quantpub` (FEP §4 discovery) and `GET /ns/quantpub` (published JSON-LD context, `application/ld+json`). `WellKnownQuantpub` schema added to api-spec.
- **Mechanism**: Fedify's typed vocab drops unknown properties, so `quant-extension.ts` wraps the outermost object's `toJsonLd` and splices the extension into the final serialized document (after Fedify's JSON-LD compaction). Wrapping only the outermost object avoids the child-splice being re-compacted into expanded-IRI form. Inbound is safe: Fedify's `fromJsonLd` type check is an `includes()`, so extra types pass through.
- **Removes the unused parallel `aurboda:` AS2 builder** (`buildCreateExercise`/`buildFeedPostActivity`) the FEP flagged as diverging; `feedPostContent`/addressing stay in `object.ts`, scalar resolution in `feed-activity.ts`.

## Notes
- `quant:series` links for a **merged** share are built over the merged span while the public series endpoint still authorizes the anchor's own window, so those links can 404 (documented in feed.md known limitations; QuantPub consumers treat series fetches as best-effort). Expanding series authorization across merge groups stays the existing planned follow-up.
- Aurboda↔Aurboda enrichment continues out-of-band via the FEP §7 id convention (unchanged); `/.well-known/aurboda` stays for challenge federation.

## Tests
- `quant-extension.test.ts`: extension props (series gating, token), document splicing (bare/activity/idempotence), real Fedify Note round-trip.
- `federation.integration.test.ts`: served object carries dual type, quant fields, AS2 window, and the @context entry; followers-only delivery carries the token on `quant:structuredUrl` and no series links.
- `well-known-router.test.ts`: discovery + context documents.
- Whole-monorepo `pnpm check` green; all 2352 backend unit tests + 21 federation integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo