### PR TITLE
docs(fep): QuantPub rev 5 — final pre-submission pass + r/QuantifiedSelf draft (#905)

### DIFF
--- a/docs/fep/quantpub-reddit-draft.md
+++ b/docs/fep/quantpub-reddit-draft.md
@@ -1,0 +1,78 @@
+# DRAFT: r/QuantifiedSelf post (QuantPub outreach, #905)
+
+> Status: **draft for review — not yet posted.** Fredrik posts this himself
+> after review, with the two screenshots captured (see placeholders). Suggested
+> flair: "Apps & Tools" (or whatever the sub currently uses for tooling).
+
+---
+
+**Title:** Making our QS tools social: a small ActivityPub vocabulary so
+home-built trackers can follow each other (RFC — looking for collaborators)
+
+---
+
+A lot of us run home-built or self-hosted tracking systems — and they're all
+islands. I've been experimenting with making mine *federated*: my workouts and
+sleep observations are ActivityPub posts, so anyone on Mastodon can follow me
+and see them. But between two tools that speak a small extra vocabulary,
+something better happens: the subscriber renders the *actual data* — an
+interactive chart with real hoverable values, not a flattened text summary and
+a static PNG.
+
+Here's the same shared run, seen by a plain Mastodon follower vs. a
+QuantPub-speaking subscriber:
+
+**[SCREENSHOT 1: Mastodon view — flattened text + PNG attachment]**
+
+**[SCREENSHOT 2: Aurboda subscriber view — native card: stat grid, personal
+message, interactive multi-metric hover chart + synced route map]**
+
+The interesting part is that the mechanism is deliberately boring, because
+mainstream fediverse servers drop anything fancy. The whole contract, which
+I've written up as a draft FEP (Fediverse Enhancement Proposal) called
+**QuantPub**, is:
+
+1. **Deliver a plain `Note`** (so Mastodon renders something sensible), with a
+   few extra typed fields riding along: activity type, the scalar summaries
+   you chose to share (`{key, value, unit}`), and links to series data.
+2. **Serve a machine-readable payload** for each shared post at a predictable
+   URL — plain JSON: typed scalars + bucketed time series (avg/min/max/count
+   per bucket). This out-of-band channel is what actually survives real-world
+   federation.
+3. **A discovery document** (`/.well-known/quantpub`) so a peer can tell your
+   host speaks the spec with one cacheable request.
+
+That's a **weekend project on top of an existing home-built tracker** — the
+publishing side needs no ActivityPub stack at all, just two-and-a-half static
+routes. Add a minimal AP actor later and you're followable from Mastodon and
+every implementing peer.
+
+Privacy is a first-class part of the spec, because QS data is sensitive:
+
+- Sharing a scalar summary (avg HR) never exposes the underlying series; series
+  are a separate per-post, per-metric opt-in.
+- Unshared data is indistinguishable from nonexistent (404, never 403).
+- Followers-only posts use capability URLs; deleting a post revokes access
+  immediately (`no-store` everywhere).
+- It's not just exercise: a generic `Observation` shape covers sleep, HRV,
+  steps, mood, glucose — anything measured over a window.
+
+Draft spec: **[link to docs/fep/quantpub.md on GitHub]**
+Running implementation (mine): **[https://aurboda.net]** — but the explicit
+goal is that you *don't* have to adopt my software. If you have a home-built
+system and this sounds interesting, I'd love feedback on the vocabulary and
+endpoint contract before I submit the FEP upstream — especially from anyone
+willing to try implementing the Level 1 publishing side against their own
+data. What metrics would you need that the recommended key set doesn't cover?
+
+---
+
+> **Pre-post checklist**
+>
+> - [ ] Capture screenshot pair (same share): Mastodon web view + Aurboda
+>   subscriber timeline card (enriched, hover chart visible). #996 shipped, so
+>   any aurboda.net-to-aurboda.net follow renders the enriched card.
+> - [ ] Replace the two link placeholders (GitHub blob URL for the FEP; keep
+>   aurboda.net).
+> - [ ] Check r/QuantifiedSelf rules for self-promotion framing (post leads
+>   with the open spec, not the product — keep it that way).

--- a/docs/fep/quantpub.md
+++ b/docs/fep/quantpub.md
@@ -334,9 +334,15 @@ On ingesting a `Create`/`Update` for a `Note`, a receiving peer:
 1. checks whether the object carries `quant:structuredUrl` (same-host, above)
    or an id matching the object-id convention (a Mastodon status id never
    does, avoiding needless requests);
-2. fetches `/.well-known/quantpub` from the object's origin host (cacheable);
-3. if the origin speaks QuantPub, fetches the structured post endpoint (§5)
-   and stores the payload alongside the sanitised note for native rendering.
+2. resolves the payload URL: a same-host `quant:structuredUrl` names it
+   directly, so no discovery fetch is needed to *locate* it; the id
+   convention instead requires `{api_base}`, taken from
+   `/.well-known/quantpub` on the object's origin host (cacheable). A
+   consumer MAY still fetch the discovery document in the
+   `quant:structuredUrl` case as a capability check on the origin, but MUST
+   NOT require it;
+3. fetches the structured post endpoint (§5) and stores the payload alongside
+   the sanitised note for native rendering.
 
 Enrichment MUST be best-effort and additive: any failure (non-QuantPub host,
 404, malformed payload, timeout) leaves the plain note intact. Fetches MUST be
@@ -377,13 +383,19 @@ for followers-only posts:
 - **Token conveyance MUST survive typed processing.** The §7 id convention
   alone yields a tokenless payload URL (a 404 for a followers-only post), and
   an extension property like `quant:structuredUrl` may be dropped by a typed
-  consumer before application code sees it (§7). Publishers MUST therefore
-  embed the token in the delivered **image attachment URLs** (`?token={token}`
-  on each `attachment` `Image` `url`) — standard AS2 attachments survive typed
-  vocabularies — and consumers SHOULD lift the token from a delivered
-  attachment URL and forward it to the structured-payload fetch. (This is what
-  Aurboda ships; see Implementations.) `quant:structuredUrl` MAY additionally
-  carry the token for consumers that preserve it.
+  consumer before application code sees it (§7). A publisher MUST therefore
+  convey the token on every followers-only delivery through at least one of
+  two channels, and MUST use the first whenever the post carries image
+  attachments: (a) the delivered **image attachment URLs** (`?token={token}`
+  on each `attachment` `Image` `url`) — standard AS2 attachments survive
+  typed vocabularies; (b) `quant:structuredUrl` carrying the token, the only
+  channel available for an **attachment-less** post (e.g. a followers-only
+  sleep observation with no chart) — its survival depends on the consumer
+  preserving unknown properties, so a publisher SHOULD attach at least one
+  tokenised image where the post has any renderable image at all. Consumers
+  SHOULD lift the token from a delivered attachment URL, falling back to a
+  same-host `quant:structuredUrl`, and forward it to the structured-payload
+  fetch. (Aurboda ships both channels; see Implementations.)
 - A request with a matching token resolves; without one, 404 (§8.3).
 - Tokens MUST be generated with a cryptographically secure RNG and MUST be
   revocable (regenerated or invalidated when the post is deleted or its


### PR DESCRIPTION
Part of #905 (does not close it — submission to the FEP repo and the actual Reddit post are Fredrik's maintainer actions).

Folds the three rev-5 items recorded on #905 from the #1002 rev-4 review:

- **§9 token conveyance** is now a conditional MUST with a stated fallback: image-attachment URLs whenever the post carries images (unchanged, and mandatory in that case); `quant:structuredUrl?token=…` named as the only channel for **attachment-less** followers-only posts (e.g. a sleep observation with no chart), with a SHOULD to attach a tokenised image whenever the post has any renderable image, and the consumer fallback order spelled out. Matches what Aurboda ships since #1034 (structuredUrl always carries the token on followers-only deliveries).
- **§7 step 2** no longer unconditionally requires the `/.well-known/quantpub` fetch: a same-host `quant:structuredUrl` names the payload URL directly, so discovery is only needed to resolve `{api_base}` under the id convention; it MAY remain as a capability check but MUST NOT be required.
- **FEP-400e dates verified** against the Codeberg FEP index (`dateReceived: 2021-02-16`, `dateFinalized: 2022-02-04`) — the citation was already correct; no change.

Also adds `docs/fep/quantpub-reddit-draft.md` — the step-3 r/QuantifiedSelf post drafted in-repo for review as the issue requests, with placeholders for the Mastodon-vs-subscriber screenshot pair and a pre-post checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo