### PR TITLE
docs(fep): QuantPub rev 6 — pre-submission consistency fixes (#905)

### DIFF
--- a/apps/backend/src/services/activitypub/timeline-enrich.ts
+++ b/apps/backend/src/services/activitypub/timeline-enrich.ts
@@ -1,11 +1,13 @@
 /**
  * Enrich a received timeline post with its native Aurboda structured data.
  *
- * A `Note` delivered over ActivityPub carries only the Mastodon-compatible HTML
- * (Fedify's typed vocab drops the `aurboda:` extension). So when a followed
- * *Aurboda* instance posts, we fetch the richer structured payload it serves at
- * `GET /public/:user/feed/:postId` and store it on the timeline entry, letting
- * the web render a native chart + typed stats instead of the text.
+ * A delivered `Note` carries the QuantPub scalar summary in-band (#896), but
+ * not the high-resolution series data. So when a followed *Aurboda* instance
+ * posts, we fetch the richer structured payload it serves at
+ * `GET /public/:user/feed/:postId` (the FEP §7 id-convention path — reliable
+ * even when a typed consumer drops in-band extension properties) and store it
+ * on the timeline entry, letting the web render a native chart + typed stats
+ * instead of the text.
  *
  * Strictly best-effort and defensive:
  * - Only Notes whose id matches Aurboda's own object-dispatcher path

--- a/docs/fep/README.md
+++ b/docs/fep/README.md
@@ -14,3 +14,7 @@ federation code, before submission to the
   (QuantPub vs. Personal Metrics Vocabulary / MetricPub) is open for community
   input. Aurboda's own implementation of the pattern is documented in
   [docs/features/feed.md](../features/feed.md).
+- **[quantpub-reddit-draft.md](./quantpub-reddit-draft.md)** — draft of the
+  r/QuantifiedSelf outreach post (issue #905 step 3), kept in-repo for review;
+  not itself a FEP. Placeholders mark the screenshots and links to fill in
+  before posting.

--- a/docs/fep/quantpub-reddit-draft.md
+++ b/docs/fep/quantpub-reddit-draft.md
@@ -12,9 +12,9 @@ home-built trackers can follow each other (RFC — looking for collaborators)
 ---
 
 A lot of us run home-built or self-hosted tracking systems — and they're all
-islands. I've been experimenting with making mine *federated*: my workouts and
-sleep observations are ActivityPub posts, so anyone on Mastodon can follow me
-and see them. But between two tools that speak a small extra vocabulary,
+islands. I've been experimenting with making mine *federated*: my workouts are
+ActivityPub posts (and the spec covers any observation — sleep, HRV, steps,
+mood, …), so anyone on Mastodon can follow me and see them. But between two tools that speak a small extra vocabulary,
 something better happens: the subscriber renders the *actual data* — an
 interactive chart with real hoverable values, not a flattened text summary and
 a static PNG.
@@ -43,7 +43,7 @@ I've written up as a draft FEP (Fediverse Enhancement Proposal) called
    host speaks the spec with one cacheable request.
 
 That's a **weekend project on top of an existing home-built tracker** — the
-publishing side needs no ActivityPub stack at all, just two-and-a-half static
+publishing side needs no ActivityPub stack at all, just two-and-a-half
 routes. Add a minimal AP actor later and you're followable from Mastodon and
 every implementing peer.
 
@@ -53,7 +53,8 @@ Privacy is a first-class part of the spec, because QS data is sensitive:
   are a separate per-post, per-metric opt-in.
 - Unshared data is indistinguishable from nonexistent (404, never 403).
 - Followers-only posts use capability URLs; deleting a post revokes access
-  immediately (`no-store` everywhere).
+  immediately (`no-store` on every data response — only the tiny discovery
+  document is cacheable).
 - It's not just exercise: a generic `Observation` shape covers sleep, HRV,
   steps, mood, glucose — anything measured over a window.
 

--- a/docs/fep/quantpub.md
+++ b/docs/fep/quantpub.md
@@ -72,8 +72,9 @@ instance. A receiving peer that recognises the pattern fetches the structured
 data; everyone else sees a perfectly good status.
 
 This is running code: Aurboda federates activity shares and long-form articles
-this way today, with a vendor-prefixed (`aurboda:`) variant of everything
-specified here. This FEP generalises it so any implementation can join.
+this way today, speaking this document's `quant:` vocabulary on the wire (see
+Implementations). This FEP generalises that running code so any implementation
+can join.
 
 ## Requirements
 


### PR DESCRIPTION
Part of #905 (does not close it). Batches the non-blocking items from the #1038 review, per the reviewer's note to fold them in before upstream submission:

1. **Motivation ↔ Implementations self-contradiction fixed**: the Motivation section no longer claims Aurboda ships a "vendor-prefixed (`aurboda:`) variant" — the `quant:` vocabulary is on the wire since #1034. Same stale wording fixed in the `timeline-enrich.ts` header (also the first checkbox of #1037).
2. **`docs/fep/README.md`** now indexes `quantpub-reddit-draft.md` and states it is not itself a FEP.
3. **Reddit-draft overstatements**: "static routes" → "routes" (the series endpoint carries the §6 authorization check); "`no-store` everywhere" → `no-store` on data responses with the cacheable discovery doc called out; workouts-are-running-code vs any-observation-is-spec claims separated.
4. Item 5 (consumer-side `quant:structuredUrl` token fallback) recorded on #1037 as a code follow-up rather than changed here.

Backend `pnpm check` green (comment-only code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VFPcqXTu9DPuARhRBnBoo