### PR TITLE
feat(federation): NodeInfo + browser fallback for actor URLs (#1047)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -58,6 +58,7 @@ import { ouraClient } from './integrations/oura/client.ts'
 import { createOwnTracksRouter } from './integrations/owntracks/router.ts'
 import { stravaClient } from './integrations/strava/client.ts'
 import { createMcpRouter } from './mcp.ts'
+import { createActorHtmlRouter } from './routes/actor-html-router.ts'
 import { createFeedTombstoneRouter } from './routes/feed-tombstone-router.ts'
 import { createOAuthRouter } from './routes/oauth-router.ts'
 import {
@@ -363,8 +364,12 @@ const main = async () => {
   // the follower's timeline (fire-and-forget, time-boxed). `backfill` is defined
   // just below and only invoked later (on an inbound Accept), so the forward
   // reference is safe.
-  const feedFederation = createFeedFederation(webHost, apiBaseUrl, onNewTimelineEntry, (user, actorUri) =>
-    backfill(user, actorUri),
+  const feedFederation = createFeedFederation(
+    webHost,
+    apiBaseUrl,
+    onNewTimelineEntry,
+    (user, actorUri) => backfill(user, actorUri),
+    wellKnown.version,
   )
   const backfill = createTimelineBackfiller(feedFederation, webHost)
   const feedDeps = { apiBaseUrl, federation: feedFederation, origin: webHost }
@@ -521,6 +526,10 @@ const main = async () => {
   // the federation integration: when the object dispatcher returns null for a
   // since-deleted post, `@fedify/express` calls next(), and this catches it.
   httpd.use(createFeedTombstoneRouter({ getTombstone: getFeedTombstone, origin: webHost }))
+
+  // Browser-facing actor URLs (#1047): Fedify answers 406 to `Accept: text/html`
+  // via the same next() fall-through, and this redirects humans to /u/:username.
+  httpd.use(createActorHtmlRouter({ origin: webHost }))
 
   httpd.use(json({ limit: '10mb' }))
 

--- a/apps/backend/src/routes/actor-html-router.test.ts
+++ b/apps/backend/src/routes/actor-html-router.test.ts
@@ -1,0 +1,41 @@
+import express from 'express'
+import supertest from 'supertest'
+import { describe, expect, test } from 'vitest'
+
+import { createActorHtmlRouter } from './actor-html-router.ts'
+
+/** Mounts the router with a fallback 404 so `next()` fall-through is observable. */
+const buildApp = (origin = 'https://aurboda.net') => {
+  const app = express()
+  app.use(createActorHtmlRouter({ origin }))
+  app.use((_req, res) => res.status(404).json({ fellThrough: true }))
+  return app
+}
+
+describe('GET /users/:username (browser HTML fallback)', () => {
+  test('redirects a browser to the public profile page', async () => {
+    const res = await supertest(buildApp())
+      .get('/users/fiddur')
+      .set('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toBe('https://aurboda.net/u/fiddur')
+  })
+
+  test('falls through for an ActivityPub Accept header (no redirect to HTML)', async () => {
+    const res = await supertest(buildApp()).get('/users/fiddur').set('Accept', 'application/activity+json')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ fellThrough: true })
+  })
+
+  test('falls through for a malformed username', async () => {
+    const res = await supertest(buildApp()).get('/users/Invalid..Name').set('Accept', 'text/html')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ fellThrough: true })
+  })
+
+  test('does not claim actor sub-resources like the outbox', async () => {
+    const res = await supertest(buildApp()).get('/users/fiddur/outbox').set('Accept', 'text/html')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({ fellThrough: true })
+  })
+})

--- a/apps/backend/src/routes/actor-html-router.ts
+++ b/apps/backend/src/routes/actor-html-router.ts
@@ -1,0 +1,43 @@
+/**
+ * Browser-facing fallback for ActivityPub actor URLs (#1047).
+ *
+ * Handles: GET /users/:username with an HTML-preferring Accept header.
+ *
+ * Fedify's actor dispatcher content-negotiates: an ActivityPub client gets the
+ * actor document, but a browser (`Accept: text/html`) makes `@fedify/express`
+ * fall through (`next()`) and then answer `406 Not acceptable` — unless a later
+ * Express route claims the request. This router — mounted right AFTER
+ * `integrateFederation`, like the feed tombstone router — is that route: it
+ * redirects a human clicking an actor link (e.g. from a Mastodon profile that
+ * didn't use the actor's `url` property) to the public profile page the SPA
+ * serves at `/u/:username`.
+ *
+ * Anything that is not an HTML request for a well-formed username falls
+ * through untouched, so an ActivityPub fetch of a nonexistent actor still ends
+ * in the plain 404, never a redirect to a 200 HTML page.
+ */
+import { Router } from 'express'
+
+import { isValidUsername } from '../api/auth-routes.ts'
+import { buildProfileUrl } from '../services/share-urls.ts'
+
+export interface ActorHtmlDeps {
+  /** Canonical web origin, e.g. `https://aurboda.net` — the profile URL base. */
+  origin: string
+}
+
+export const createActorHtmlRouter = (deps: ActorHtmlDeps): Router => {
+  const router = Router()
+
+  router.get('/users/:username', (req, res, next) => {
+    if (!isValidUsername(req.params.username)) return next()
+    // `accepts` honours quality values, so a browser's
+    // `text/html,application/xhtml+xml,…` prefers html while an ActivityPub
+    // client's `application/activity+json` (or a bare `Accept: */*` already
+    // answered by Fedify before this router runs) does not.
+    if (!req.accepts('html')) return next()
+    res.redirect(302, buildProfileUrl(deps.origin, req.params.username))
+  })
+
+  return router
+}

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -90,6 +90,34 @@ describe('Feed federation actor + WebFinger', () => {
     expect(publicKey.publicKeyPem).toContain('BEGIN PUBLIC KEY')
     // Default account is open — not a locked (manual-approval) account.
     expect(doc.manuallyApprovesFollowers).toBe(false)
+    // Human-facing profile link, so clients send browsers to the SPA page
+    // instead of the 406-answering actor document (#1047).
+    expect(doc.url).toBe(`${ORIGIN}/u/${user}`)
+  })
+
+  test('serves the NodeInfo JRD at /.well-known/nodeinfo (#1047)', async () => {
+    const res = await fed.fetch(new Request(`${ORIGIN}/.well-known/nodeinfo`), {
+      contextData: undefined,
+      onNotAcceptable: notFound,
+      onNotFound: notFound,
+    })
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as { links: { href: string; rel: string }[] }
+    const link = doc.links.find((l) => l.rel === 'http://nodeinfo.diaspora.software/ns/schema/2.1')
+    expect(link?.href).toBe(`${ORIGIN}/nodeinfo/2.1`)
+  })
+
+  test('serves NodeInfo 2.1 identifying the software (#1047)', async () => {
+    const res = await fed.fetch(new Request(`${ORIGIN}/nodeinfo/2.1`), {
+      contextData: undefined,
+      onNotAcceptable: notFound,
+      onNotFound: notFound,
+    })
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as Record<string, unknown>
+    expect(doc.version).toBe('2.1')
+    expect(doc.software).toMatchObject({ name: 'aurboda', version: 'dev' })
+    expect(doc.protocols).toEqual(['activitypub'])
   })
 
   test('advertises manuallyApprovesFollowers when the user requires manual approval', async () => {

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -219,6 +219,8 @@ export const createFeedFederation = (
    * sent becomes accepted, to backfill the followee's recent public posts.
    */
   onFollowAccepted?: (user: string, actorUri: string) => void,
+  /** Deployed software version (BUILD_SHA), reported in NodeInfo. */
+  version = 'dev',
 ): Federation<void> => {
   const federation = createFederation<void>({
     kv: new MemoryKvStore(),
@@ -237,6 +239,22 @@ export const createFeedFederation = (
   // Fetches native structured data (typed metrics + series) for ingested posts
   // that come from Aurboda instances, so the web can render a native chart.
   const enrich = createAurbodaEnricher(origin)
+
+  // NodeInfo instance metadata (#1047). Fedify serves the `/.well-known/nodeinfo`
+  // JRD automatically once a dispatcher is registered; peers and crawlers use it
+  // to identify the software (some, like FitPub, gate follow-ability on it).
+  // Usage statistics are deliberately absent/zero: the per-user-database
+  // architecture has no cheap global user or post counts, and NodeInfo allows
+  // omitting `users.total`.
+  federation.setNodeInfoDispatcher('/nodeinfo/2.1', () => ({
+    protocols: ['activitypub'],
+    software: {
+      name: 'aurboda',
+      repository: new URL('https://github.com/fiddur/aurboda'),
+      version,
+    },
+    usage: { localComments: 0, localPosts: 0, users: {} },
+  }))
 
   federation
     .setActorDispatcher('/users/{identifier}', async (ctx, identifier) => {
@@ -265,6 +283,10 @@ export const createFeedFederation = (
         outbox: ctx.getOutboxUri(identifier),
         preferredUsername: identifier,
         publicKey: keys[0].cryptographicKey,
+        // The human-facing profile page. Mastodon-class clients link people
+        // here instead of the actor document (whose content negotiation
+        // answers 406 to a browser — see the HTML fallback router, #1047).
+        url: new URL(buildProfileUrl(origin, identifier)),
       })
     })
     .setKeyPairsDispatcher(async (_ctx, identifier) => {

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -597,7 +597,9 @@ Public / federation (unauthenticated):
 | `GET /.well-known/webfinger`                                 | Resolve `acct:<username>@<host>` → the actor                                                               |
 | `GET /.well-known/quantpub`                                  | QuantPub discovery document (FEP §4): product, versions, `api_base`                                        |
 | `GET /ns/quantpub`                                           | The published QuantPub JSON-LD `@context` document (`application/ld+json`)                                 |
-| `GET /users/:username`                                       | The actor document (`Person`)                                                                              |
+| `GET /.well-known/nodeinfo`                                  | NodeInfo JRD pointing at the 2.1 document (#1047)                                                          |
+| `GET /nodeinfo/2.1`                                          | NodeInfo 2.1: software `aurboda` + version, `activitypub` protocol (no usage stats — per-user DBs)         |
+| `GET /users/:username`                                       | The actor document (`Person`); a browser (`Accept: text/html`) is 302-redirected to `/u/:username`         |
 | `GET /users/:username/outbox`                                | Public + unlisted posts as `Create` activities                                                             |
 | `GET /users/:username/followers`                             | The actor's followers collection                                                                           |
 | `GET /users/:username/following`                             | The actor's following collection (accepted follows only)                                                   |

--- a/nginx.conf
+++ b/nginx.conf
@@ -101,6 +101,27 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # NodeInfo instance metadata (JRD + the 2.1 document, served by Fedify).
+    # Without these blocks the paths fall through to the SPA and answer 200
+    # with HTML, which misleads fediverse crawlers (#1047).
+    location = /.well-known/nodeinfo {
+        proxy_pass http://127.0.0.1:3000/.well-known/nodeinfo;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /nodeinfo/ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ActivityPub actor documents + inbox/outbox/followers (Fedify, at the app
     # root). A dedicated prefix that never collides with the SPA's /u/ pages, so
     # no Accept-header content negotiation is needed. proxy_pass without a


### PR DESCRIPTION
Closes #1047 (user report relayed by Fredrik; verified live on aurboda.net).

**Before:** `/.well-known/nodeinfo` fell through nginx to the SPA and answered **200 with HTML** (worse than a 404 for crawlers); `GET /users/fiddur` with a browser Accept header answered **406 Not acceptable**. WebFinger and AP-Accept actor fetches were fine.

**Changes:**
- **NodeInfo** (`federation.setNodeInfoDispatcher('/nodeinfo/2.1', …)`): software `aurboda` + BUILD_SHA version, `activitypub` protocol; Fedify serves the `/.well-known/nodeinfo` JRD automatically. Usage stats deliberately absent/zero — the per-user-database architecture has no cheap global counts, and NodeInfo allows omitting them. New nginx locations proxy both paths.
- **Browser fallback for actor URLs**: new `actor-html-router` mounted right after `integrateFederation` (same fallthrough pattern as the feed tombstone router) — an HTML-preferring `GET /users/:username` 302-redirects to the `/u/:username` public profile page; AP requests and malformed usernames fall through untouched, so a fetch of a nonexistent actor still 404s.
- **Actor `url` property** set to the profile page, so Mastodon-class clients link humans there directly.

Note for the FitPub thread (fitpub#455): FitPub gates follow-ability on NodeInfo *software identity* (`name: fitpub`), so this alone doesn't make Aurboda followable from FitPub — but it gives their side a standard hook to extend.

Tests: 4 new unit tests (redirect/fallthrough matrix), 2 new integration tests (JRD + 2.1 document) + actor `url` assertion; whole-monorepo `pnpm check` green, federation integration suite 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwoP1SqJhHgHiEEoEQtUjT
