### PR TITLE
feat(federation): federate avatar changes (Update{Person} + versioned icon)

### DIFF
--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -72,7 +72,7 @@ import {
   toDeliverableArticle,
   toDeliverableChallenge,
 } from './services/activitypub/deliver.ts'
-import { createFeedFederation } from './services/activitypub/federation.ts'
+import { createFeedFederation, deliverActorUpdate } from './services/activitypub/federation.ts'
 import { createTimelineBackfiller } from './services/activitypub/timeline-backfill.ts'
 import { createAurbodaEnrichAttempt } from './services/activitypub/timeline-enrich.ts'
 import { auditError, auditInfo } from './services/audit-log.ts'
@@ -646,6 +646,13 @@ const main = async () => {
     garmin,
     httpd,
     invitationAuth,
+    // Tell followers' servers the profile changed — they cache the avatar and
+    // re-download only on an Update{Person} or a changed icon URL.
+    onAvatarChanged: (user) => {
+      deliverActorUpdate(feedDeps, user).catch((error) =>
+        console.warn(`⚠️ actor Update delivery failed for ${user}:`, error),
+      )
+    },
     ouraWebhookManager,
     retroEnrichTimeline,
     syncProvider,

--- a/apps/backend/src/api/rest-routes.ts
+++ b/apps/backend/src/api/rest-routes.ts
@@ -100,6 +100,8 @@ interface RestRoutesDeps {
   followerActions: FollowerActions
   timelineHub: TimelineHub
   retroEnrichTimeline: RetroEnrichTrigger
+  /** Fire-and-forget: federate an `Update{Person}` after an avatar change. */
+  onAvatarChanged: (user: string) => void
   /** Merge-group/window resolution behind the auto-share rule preview (#903). */
   autosharePreviewDeps: Pick<
     AutoshareDeps,
@@ -125,6 +127,7 @@ export const mountRestRouters = ({
   feedDeliver,
   followActions,
   followerActions,
+  onAvatarChanged,
   retroEnrichTimeline,
   timelineHub,
   ouraWebhookManager,
@@ -168,7 +171,7 @@ export const mountRestRouters = ({
   httpd.use(createRawRecordsRouter(authMiddleware))
   httpd.use('/dashboard', createDashboardRouter(authMiddleware))
   httpd.use('/shared-dashboards', createSharedDashboardsRouter(authMiddleware, webHost))
-  httpd.use('/profile', createProfileRouter(authMiddleware, webHost))
+  httpd.use('/profile', createProfileRouter(authMiddleware, webHost, onAvatarChanged))
   // Mount the following + followers routers before `/feed` so `/feed/following/*`
   // and `/feed/followers/*` (two path segments) resolve here and never touch the
   // feed router's `/:postId`.

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -503,6 +503,7 @@ export { deleteIcon, getIcon, insertIcon } from './icons.ts'
 export {
   deleteProfileAvatar,
   getProfileAvatar,
+  getProfileAvatarVersion,
   type ProfileAvatar,
   upsertProfileAvatar,
 } from './profile-avatar.ts'

--- a/apps/backend/src/db/profile-avatar.ts
+++ b/apps/backend/src/db/profile-avatar.ts
@@ -25,6 +25,19 @@ export const getProfileAvatar = async (user: string): Promise<ProfileAvatar | un
   }
 }
 
+/**
+ * The avatar's last-modified time WITHOUT loading the image bytes — the actor
+ * document embeds it as a cache-busting `?v=` on the icon URL (a remote server
+ * only re-downloads an avatar when the URL changes), so this runs on every
+ * actor fetch. `undefined` = no uploaded avatar (identicon fallback, which is
+ * deterministic and needs no version).
+ */
+export const getProfileAvatarVersion = async (user: string): Promise<Date | undefined> => {
+  const result = await query(user, `SELECT updated_at FROM profile_avatar WHERE singleton`)
+  if (result.rows.length === 0) return undefined
+  return result.rows[0].updated_at as Date
+}
+
 export const upsertProfileAvatar = async (user: string, contentType: string, data: Buffer): Promise<void> => {
   await query(
     user,

--- a/apps/backend/src/routes/profile-router.test.ts
+++ b/apps/backend/src/routes/profile-router.test.ts
@@ -12,13 +12,16 @@ const db = await import('../db/index.ts')
 
 const { createProfileRouter } = await import('./profile-router.ts')
 
-const buildApp = () => {
+const buildApp = (onAvatarChanged?: (user: string) => void) => {
   const app = express()
   const auth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
     req.user = 'tester'
     next()
   }
-  app.use('/profile', createProfileRouter(auth, 'https://aurboda.net') as unknown as express.RequestHandler)
+  app.use(
+    '/profile',
+    createProfileRouter(auth, 'https://aurboda.net', onAvatarChanged) as unknown as express.RequestHandler,
+  )
   return app
 }
 
@@ -39,6 +42,18 @@ describe('POST /profile/avatar', () => {
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ success: true, url: 'https://aurboda.net/u/tester/avatar.png' })
     expect(db.upsertProfileAvatar).toHaveBeenCalledWith('tester', 'image/webp', expect.any(Buffer))
+  })
+
+  test('notifies onAvatarChanged after a successful upload, but not on rejection', async () => {
+    const onAvatarChanged = vi.fn()
+    const app = buildApp(onAvatarChanged)
+    await supertest(app)
+      .post('/profile/avatar')
+      .attach('avatar', await pngBuffer(), { contentType: 'image/png', filename: 'a.png' })
+    expect(onAvatarChanged).toHaveBeenCalledWith('tester')
+    onAvatarChanged.mockClear()
+    await supertest(app).post('/profile/avatar')
+    expect(onAvatarChanged).not.toHaveBeenCalled()
   })
 
   test('rejects when no file is uploaded', async () => {
@@ -65,10 +80,12 @@ describe('POST /profile/avatar', () => {
 })
 
 describe('DELETE /profile/avatar', () => {
-  test('removes the avatar', async () => {
-    const res = await supertest(buildApp()).delete('/profile/avatar')
+  test('removes the avatar and notifies onAvatarChanged', async () => {
+    const onAvatarChanged = vi.fn()
+    const res = await supertest(buildApp(onAvatarChanged)).delete('/profile/avatar')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ success: true })
     expect(db.deleteProfileAvatar).toHaveBeenCalledWith('tester')
+    expect(onAvatarChanged).toHaveBeenCalledWith('tester')
   })
 })

--- a/apps/backend/src/routes/profile-router.ts
+++ b/apps/backend/src/routes/profile-router.ts
@@ -22,7 +22,16 @@ const upload = multer({
   storage: multer.memoryStorage(),
 })
 
-export const createProfileRouter = (authMiddleware: RequestHandler, webHost: string): TypedRouter => {
+export const createProfileRouter = (
+  authMiddleware: RequestHandler,
+  webHost: string,
+  /**
+   * Fire-and-forget: called after the avatar is uploaded/replaced/removed, so
+   * federation can deliver an `Update{Person}` to followers (remote servers
+   * cache the old avatar until told otherwise).
+   */
+  onAvatarChanged?: (user: string) => void,
+): TypedRouter => {
   const router = typedRouter()
 
   router.post<Record<string, never>, { success: boolean; url?: string; error?: string }>(
@@ -53,12 +62,14 @@ export const createProfileRouter = (authMiddleware: RequestHandler, webHost: str
       }
 
       await upsertProfileAvatar(user, processed.content_type, processed.data)
+      onAvatarChanged?.(user)
       res.json({ success: true, url: `${buildProfileUrl(webHost, user)}/avatar.png` })
     },
   )
 
   router.delete<Record<string, never>, { success: boolean }>('/avatar', authMiddleware, async (req, res) => {
     await deleteProfileAvatar(req.user!)
+    onAvatarChanged?.(req.user!)
     res.json({ success: true })
   })
 

--- a/apps/backend/src/services/activitypub/federation.integration.test.ts
+++ b/apps/backend/src/services/activitypub/federation.integration.test.ts
@@ -18,11 +18,12 @@ import {
   type FeedPostInput,
   getFeedTombstone,
 } from '../../db/feed.ts'
+import { getProfileAvatarVersion, upsertProfileAvatar } from '../../db/profile-avatar.ts'
 import { upsertUserSettings } from '../../db/settings.ts'
 import { createFeedTombstoneRouter } from '../../routes/feed-tombstone-router.ts'
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../../test/db-test-helper.ts'
 import { buildFeedUpdate } from './deliver.ts'
-import { createFeedFederation } from './federation.ts'
+import { buildActorPerson, createFeedFederation } from './federation.ts'
 
 const CONTAINER_TIMEOUT = 120_000
 const ORIGIN = 'https://aurboda.example'
@@ -93,6 +94,35 @@ describe('Feed federation actor + WebFinger', () => {
     // Human-facing profile link, so clients send browsers to the SPA page
     // instead of the 406-answering actor document (#1047).
     expect(doc.url).toBe(`${ORIGIN}/u/${user}`)
+  })
+
+  test('versions the actor icon URL by the avatar upload time', async () => {
+    const user = getTestUser()
+    // No uploaded avatar: the deterministic identicon needs no version param.
+    const before = await fetchAs2(`/users/${user}`)
+    const beforeDoc = (await before.json()) as { icon: { url: string } }
+    expect(beforeDoc.icon.url).toBe(`${ORIGIN}/u/${user}/avatar.png`)
+
+    await upsertProfileAvatar(user, 'image/webp', Buffer.from('img'))
+    const version = await getProfileAvatarVersion(user)
+    const after = await fetchAs2(`/users/${user}`)
+    const afterDoc = (await after.json()) as { icon: { url: string } }
+    // Remote servers re-download an avatar only when its URL changes, so the
+    // upload MUST change the URL (and each re-upload changes it again).
+    expect(afterDoc.icon.url).toBe(`${ORIGIN}/u/${user}/avatar.png?v=${version?.getTime()}`)
+  })
+
+  test('buildActorPerson (the Update{Person} payload) matches the served actor document', async () => {
+    const user = getTestUser()
+    await upsertProfileAvatar(user, 'image/webp', Buffer.from('img'))
+    const ctx = fed.createContext(new URL(ORIGIN), undefined)
+    const person = await buildActorPerson(ctx, user, ORIGIN)
+    expect(person?.id?.href).toBe(`${ORIGIN}/users/${user}`)
+    const served = await fetchAs2(`/users/${user}`)
+    const servedDoc = (await served.json()) as Record<string, unknown>
+    const builtDoc = (await person!.toJsonLd({ format: 'compact' })) as Record<string, unknown>
+    // The profile-change Update embeds exactly what the actor URL serves.
+    expect(builtDoc).toEqual(servedDoc)
   })
 
   test('serves the NodeInfo JRD at /.well-known/nodeinfo (#1047)', async () => {

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -1,7 +1,13 @@
 import type { FeedStructuredPost } from '@aurboda/api-spec'
 import type { Actor } from '@fedify/fedify/vocab'
 
-import { createFederation, type Federation, type InboxContext, MemoryKvStore } from '@fedify/fedify'
+import {
+  type Context,
+  createFederation,
+  type Federation,
+  type InboxContext,
+  MemoryKvStore,
+} from '@fedify/fedify'
 import {
   Accept,
   Create,
@@ -48,6 +54,7 @@ import {
   getFeedFollowingByActor,
   getFeedPostById,
   getOrCreateActorKeyPair,
+  getProfileAvatarVersion,
   getUserSettings,
   isMissingDatabase,
   listAcceptedFeedFollowing,
@@ -73,7 +80,7 @@ import {
   toDeliverableChallenge,
 } from './deliver.ts'
 import { toCryptoKeyPair } from './keys.ts'
-import { isPubliclyVisible } from './object.ts'
+import { AS_PUBLIC, isPubliclyVisible } from './object.ts'
 import { capabilityTokenFrom, createAurbodaEnricher } from './timeline-enrich.ts'
 import { extractNoteImages, noteToTimelineInput } from './timeline-ingest.ts'
 
@@ -209,6 +216,83 @@ const ingestFeedActivity = async (
   }
 }
 
+/**
+ * Build a user's full `Person` actor document — shared by the actor dispatcher
+ * and the profile-change `Update{Person}` delivery, so followers' servers
+ * always receive exactly the representation the actor URL serves. The icon URL
+ * carries the avatar's `updated_at` as a cache-busting `?v=`: remote servers
+ * (Mastodon et al.) copy a remote avatar once and re-download it only when the
+ * URL changes, so a changed avatar must change the URL.
+ */
+export const buildActorPerson = async (
+  ctx: Context<void>,
+  identifier: string,
+  origin: string,
+): Promise<Person | null> => {
+  if (!isValidUsername(identifier)) return null
+  let keys
+  try {
+    keys = await ctx.getActorKeyPairs(identifier)
+  } catch (error) {
+    if (isMissingDatabase(error)) return null
+    throw error
+  }
+  if (keys.length === 0) return null
+  // Advertise "locked account" when the user requires manual approval, so
+  // Mastodon et al. show a follow *request* and hold the follow pending
+  // (matching our own inbox behaviour of deferring the Accept).
+  const settings = await getUserSettings(identifier)
+  // Avatar served on the web host; always resolves (identicon fallback), so
+  // remote servers always have an actor icon to show. No `?v=` while the
+  // deterministic identicon is in use — the transition to a first upload
+  // changes the URL by adding one.
+  const avatarVersion = await getProfileAvatarVersion(identifier)
+  const iconUrl = new URL(`${buildProfileUrl(origin, identifier)}/avatar.png`)
+  if (avatarVersion) iconUrl.searchParams.set('v', String(avatarVersion.getTime()))
+  return new Person({
+    followers: ctx.getFollowersUri(identifier),
+    following: ctx.getFollowingUri(identifier),
+    icon: new Image({ url: iconUrl }),
+    id: ctx.getActorUri(identifier),
+    inbox: ctx.getInboxUri(identifier),
+    manuallyApprovesFollowers: settings?.manually_approve_followers === true,
+    outbox: ctx.getOutboxUri(identifier),
+    preferredUsername: identifier,
+    publicKey: keys[0].cryptographicKey,
+    // The human-facing profile page. Mastodon-class clients link people
+    // here instead of the actor document (whose content negotiation
+    // answers 406 to a browser — see the HTML fallback router, #1047).
+    url: new URL(buildProfileUrl(origin, identifier)),
+  })
+}
+
+/**
+ * Deliver an `Update{Person}` to the user's accepted followers after a profile
+ * change (avatar upload/removal). Without it, a follower's server never
+ * refreshes its cached copy of the actor: Mastodon re-downloads an avatar only
+ * on an incoming actor Update or a changed icon URL, and until now Aurboda
+ * produced neither signal. Fire-and-forget at the call site — a delivery
+ * failure must never fail the profile change itself.
+ */
+export const deliverActorUpdate = async (
+  deps: { federation: Federation<void>; origin: string },
+  user: string,
+): Promise<void> => {
+  const ctx = await deps.federation.createContext(new URL(deps.origin))
+  const person = await buildActorPerson(ctx, user, deps.origin)
+  if (person?.id == null) return
+  const update = new Update({
+    actor: person.id,
+    cc: ctx.getFollowersUri(user),
+    // Mastodon-style per-change id fragment; profile updates are not
+    // dereferenceable objects, so uniqueness is all the id needs.
+    id: new URL(`${person.id.href}#updates/${Date.now()}`),
+    object: person,
+    to: new URL(AS_PUBLIC),
+  })
+  await ctx.sendActivity({ identifier: user }, 'followers', update)
+}
+
 export const createFeedFederation = (
   origin: string,
   apiBaseUrl: string,
@@ -257,38 +341,9 @@ export const createFeedFederation = (
   }))
 
   federation
-    .setActorDispatcher('/users/{identifier}', async (ctx, identifier) => {
-      if (!isValidUsername(identifier)) return null
-      let keys
-      try {
-        keys = await ctx.getActorKeyPairs(identifier)
-      } catch (error) {
-        if (isMissingDatabase(error)) return null
-        throw error
-      }
-      if (keys.length === 0) return null
-      // Advertise "locked account" when the user requires manual approval, so
-      // Mastodon et al. show a follow *request* and hold the follow pending
-      // (matching our own inbox behaviour of deferring the Accept).
-      const settings = await getUserSettings(identifier)
-      return new Person({
-        followers: ctx.getFollowersUri(identifier),
-        following: ctx.getFollowingUri(identifier),
-        // Avatar served on the web host; always resolves (identicon fallback),
-        // so remote servers like Mastodon always have an actor icon to show.
-        icon: new Image({ url: new URL(`${buildProfileUrl(origin, identifier)}/avatar.png`) }),
-        id: ctx.getActorUri(identifier),
-        inbox: ctx.getInboxUri(identifier),
-        manuallyApprovesFollowers: settings?.manually_approve_followers === true,
-        outbox: ctx.getOutboxUri(identifier),
-        preferredUsername: identifier,
-        publicKey: keys[0].cryptographicKey,
-        // The human-facing profile page. Mastodon-class clients link people
-        // here instead of the actor document (whose content negotiation
-        // answers 406 to a browser — see the HTML fallback router, #1047).
-        url: new URL(buildProfileUrl(origin, identifier)),
-      })
-    })
+    .setActorDispatcher('/users/{identifier}', (ctx, identifier) =>
+      buildActorPerson(ctx, identifier, origin),
+    )
     .setKeyPairsDispatcher(async (_ctx, identifier) => {
       if (!isValidUsername(identifier)) return []
       try {

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -608,6 +608,11 @@ Public / federation (unauthenticated):
 | `GET /users/:username/feed/:postId`                          | A single post's `Note` — an activity share or an article (or `410` Tombstone once deleted)                 |
 | `POST /users/:username/inbox` (+ `/inbox`)                   | Inbound `Follow` / `Undo{Follow}` / `Accept` / `Reject` (HTTP-Signature verified)                          |
 
+The actor's `icon` URL carries the avatar's upload time as a `?v=` version, and an avatar
+upload/removal delivers an `Update{Person}` to accepted followers — remote servers (Mastodon
+et al.) cache a copied avatar and re-download it only on one of those two signals, so without
+them a changed avatar never propagates.
+
 The owner-facing capability is also available over MCP as `list_feed`, `share_activity`,
 `preview_activity_share`, `share_challenge`, `create_article`, `update_article`, `export_article_markdown`, `update_feed_post`,
 `delete_feed_post`, `list_following`, `follow_actor`, `unfollow_actor`, `list_followers`,


### PR DESCRIPTION
Fredrik's avatar never refreshed when viewed from mas.to. Root cause: Mastodon-class servers copy a remote avatar once and re-download it **only** when the actor's icon URL changes or an `Update{Person}` arrives — and Aurboda produced neither signal (stable `/u/:username/avatar.png` URL; no actor-update delivery anywhere in the codebase).

**Changes** (both halves of the standard pattern, cf. FitPub's actor-update flow):

- **Versioned icon URL**: the actor document's `icon` now carries the avatar's `updated_at` as `?v=` (new lean `getProfileAvatarVersion` — no image bytes loaded on actor fetches). The identicon fallback stays unversioned; the first upload changes the URL by adding the param. WebFinger's avatar rel derives from the same icon, so it versions too.
- **`Update{Person}` on change**: `Person` building is extracted to `buildActorPerson`, shared by the actor dispatcher and the new `deliverActorUpdate`, which sends `Update{Person}` to accepted followers — an integration test asserts the Update's embedded actor equals the served actor document byte-for-byte. Avatar upload/delete fire it via a fire-and-forget `onAvatarChanged` hook (a delivery failure never fails the profile change).

After deploy: re-uploading the avatar (or any avatar change) pushes the refresh to followers' servers immediately; servers without a follow relationship pick the new URL up on their next actor re-fetch.

Tests: router callback matrix (upload fires, rejection doesn't, delete fires), icon-versioning integration test, Update-payload ≡ served-document equality test. Whole-monorepo `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwoP1SqJhHgHiEEoEQtUjT
