### PR TITLE
fix(web): charts use full card width on mobile

### DIFF
--- a/apps/web/src/components/charts/CombinedMetricChart.tsx
+++ b/apps/web/src/components/charts/CombinedMetricChart.tsx
@@ -18,7 +18,13 @@ import * as d3 from 'd3'
 import { format } from 'date-fns'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
-import { findNearest, findStageAtTime } from './chart-utils'
+import {
+  chartRightMargin,
+  countRightAxes,
+  findNearest,
+  findStageAtTime,
+  MAX_RIGHT_AXES,
+} from './chart-utils'
 import { STAGE_COLORS, STAGE_LABELS, STAGE_Y_ORDER, type SleepStage } from './sleep-utils'
 import './CombinedMetricChart.css'
 
@@ -44,9 +50,13 @@ interface CombinedMetricChartProps {
 }
 
 const CHART_HEIGHT = 260
-/** Exported so callers sizing their fetch to the drawable width use the same margins. */
-export const CHART_MARGIN = { bottom: 30, left: 50, right: 155, top: 10 }
-const MAX_RIGHT_AXES = 2
+/**
+ * Exported so callers sizing their fetch to the drawable width use the same
+ * margins. `right` is the MAXIMUM (two right axes drawn); the rendered chart
+ * reclaims unused axis space via `chartRightMargin`, so a fetch sized with
+ * this is at worst slightly coarser than the drawn width, never too fine.
+ */
+export const CHART_MARGIN = { bottom: 30, left: 50, right: chartRightMargin(MAX_RIGHT_AXES), top: 10 }
 const SPARSE_THRESHOLD = 10
 
 /** Hypnogram Y-axis labels in display order (top to bottom). */
@@ -354,7 +364,11 @@ const renderChart = ({
   const svg = d3.select(svgRef.current)
   svg.selectAll('*').remove()
 
-  const innerWidth = containerWidth - CHART_MARGIN.left - CHART_MARGIN.right
+  // Reserve right margin only for the right axes actually drawn — a fixed
+  // maximum squeezed the plot to half a phone card's width in the common
+  // single-metric case.
+  const marginRight = chartRightMargin(countRightAxes(!!hasHypnogram, overlays))
+  const innerWidth = containerWidth - CHART_MARGIN.left - marginRight
   const innerHeight = CHART_HEIGHT - CHART_MARGIN.top - CHART_MARGIN.bottom
 
   svg.attr('width', containerWidth).attr('height', CHART_HEIGHT)
@@ -368,7 +382,9 @@ const renderChart = ({
     .call(
       d3
         .axisBottom(xScale)
-        .ticks(6)
+        // A "HH:mm" tick needs ~60px to stay legible; d3 treats this as a
+        // hint, so clamp instead of letting a narrow phone card overlap them.
+        .ticks(Math.max(3, Math.min(6, Math.floor(innerWidth / 60))))
         .tickFormat((d) => format(d as Date, 'HH:mm')),
     )
     .selectAll('text')

--- a/apps/web/src/components/charts/chart-utils.test.ts
+++ b/apps/web/src/components/charts/chart-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { findNearest, findStageAtTime } from './chart-utils'
+import { chartRightMargin, countRightAxes, findNearest, findStageAtTime } from './chart-utils'
 
 describe('findNearest', () => {
   test('returns undefined for empty data', () => {
@@ -91,5 +91,36 @@ describe('findStageAtTime', () => {
 
   test('returns undefined for empty stages', () => {
     expect(findStageAtTime([], new Date('2024-01-15T00:15:00Z'))).toBeUndefined()
+  })
+})
+
+describe('countRightAxes / chartRightMargin', () => {
+  const overlay = (showAxis: boolean) => ({ showAxis })
+
+  test('a single overlay takes the left axis — no right margin reservation', () => {
+    expect(countRightAxes(false, [overlay(true)])).toBe(0)
+    expect(chartRightMargin(0)).toBe(14)
+  })
+
+  test('with a hypnogram, the first overlay already goes right', () => {
+    expect(countRightAxes(true, [overlay(true)])).toBe(1)
+  })
+
+  test('second and third overlays get right axes, capped at two', () => {
+    expect(countRightAxes(false, [overlay(true), overlay(true)])).toBe(1)
+    expect(countRightAxes(false, [overlay(true), overlay(true), overlay(true)])).toBe(2)
+    expect(countRightAxes(false, [overlay(true), overlay(true), overlay(true), overlay(true)])).toBe(2)
+  })
+
+  test('an axis-less overlay claims the left slot but never a right one', () => {
+    // Mirrors drawOverlays: the first overlay marks the left axis used even
+    // when it draws no axis, so the next one goes right.
+    expect(countRightAxes(false, [overlay(false), overlay(true)])).toBe(1)
+    expect(countRightAxes(false, [overlay(true), overlay(false)])).toBe(0)
+  })
+
+  test('margin grows 45px per axis plus label headroom', () => {
+    expect(chartRightMargin(1)).toBe(65)
+    expect(chartRightMargin(2)).toBe(110)
   })
 })

--- a/apps/web/src/components/charts/chart-utils.ts
+++ b/apps/web/src/components/charts/chart-utils.ts
@@ -5,6 +5,39 @@ import type { SleepStage } from './sleep-utils'
 
 import { STAGE_LABELS } from './sleep-utils'
 
+/** Right y-axes the chart can draw (mirrors CombinedMetricChart's cap). */
+export const MAX_RIGHT_AXES = 2
+
+/**
+ * How many RIGHT y-axes the chart will draw for these overlays — the same
+ * axis-allocation walk `drawOverlays` performs: the first overlay takes the
+ * left axis (whether or not it shows one) unless a hypnogram already holds it,
+ * later overlays go right, and only `showAxis` overlays up to the cap actually
+ * draw an axis there.
+ */
+export const countRightAxes = (hasHypnogram: boolean, overlays: { showAxis: boolean }[]): number => {
+  let rightAxisCount = 0
+  let leftUsed = false
+  for (const overlay of overlays) {
+    if (!leftUsed && !hasHypnogram) {
+      leftUsed = true
+    } else if (overlay.showAxis && rightAxisCount < MAX_RIGHT_AXES) {
+      rightAxisCount++
+    }
+  }
+  return rightAxisCount
+}
+
+/**
+ * The right chart margin for a given number of drawn right axes: axes sit
+ * 45px apart, the outermost needs ~20px more for its tick + unit labels, and
+ * an axis-less chart keeps only a small breathing edge. Reserving a fixed
+ * maximum instead squeezed the plot to half a phone card's width when only
+ * one metric was shown (the common feed-card case).
+ */
+export const chartRightMargin = (rightAxes: number): number =>
+  rightAxes === 0 ? 14 : rightAxes * 45 + 20
+
 /**
  * Find the nearest data point to a given time using binary search.
  * Returns the [Date, number] tuple closest to `targetTime`, or undefined if data is empty.


### PR DESCRIPTION
Fredrik's report (with mobile screenshot): charts on the public feed, public profile, and activity pages don't use the available width on mobile.

**Root cause:** `CombinedMetricChart` (shared by all those pages) reserved a fixed `CHART_MARGIN.right = 155` — space for its maximum of two right-side y-axes — regardless of how many are actually drawn. In the common feed-card case (one metric, left axis only, zero right axes) a ~360px phone card left the plot ~155px wide, under half the card, and the squeezed x-axis crammed its `HH:mm` ticks into an overlapping smear.

**Fix:**
- Right margin computed per render from the right axes actually drawn: new pure `countRightAxes` (mirrors `drawOverlays`' axis-allocation walk exactly, including the axis-less-overlay-claims-left quirk) and `chartRightMargin` (14px bare edge; 45px per axis + 20px label headroom) in `chart-utils.ts`, both unit-tested. Single-metric mobile plot gains ~140px.
- X-tick count clamps to ~60px per label instead of a fixed 6-tick hint, so narrow cards get 3–4 legible ticks.
- `CHART_MARGIN` stays exported as the **maximum** for fetch-width sizing (`ActivityChart` uses it to pick bucket resolution) — a fetch sized with it is at worst slightly coarser than the drawn width, never too fine.

586 web tests green (17 in chart-utils, 6 new), whole-monorepo check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwoP1SqJhHgHiEEoEQtUjT
