### PR TITLE
feat(feed): timeline replies setting + involvement-aware, reliable notifications (#1060)

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/PostNotifications.kt
+++ b/apps/android/app/src/main/java/net/aurboda/PostNotifications.kt
@@ -20,6 +20,14 @@ data class TimelineEntry(
     @SerialName("display_name") val displayName: String? = null,
     val content: String = "",
     @SerialName("published_at") val publishedAt: String,
+    // When this instance RECEIVED the post — monotonic per timeline, unlike
+    // `published_at`, which can arrive out of order after federation retries.
+    // Nullable for a backend that predates the field (rolling deploy).
+    @SerialName("received_at") val receivedAt: String? = null,
+    // Set when the post is a reply; `inReplyToMine` marks a reply to one of
+    // the reader's own posts (always notified — you're involved).
+    @SerialName("in_reply_to_uri") val inReplyToUri: String? = null,
+    @SerialName("in_reply_to_mine") val inReplyToMine: Boolean = false,
 ) {
     /** Best available human name for the notification title. */
     val authorLabel: String get() = displayName ?: handle ?: actorUri
@@ -59,10 +67,17 @@ fun parsePublishedAt(value: String): Instant? =
 /**
  * Decide which timeline posts to notify about.
  *
- * Notify a post when it is (a) newer than [highWater], and (b) from an actor in
- * [notifyActorUris] (a followed account with notifications left on). The new
- * high-water mark advances to the latest post seen across the whole page — so a
- * muted or already-seen post never re-triggers.
+ * Notify a post when it is (a) newer than [highWater], (b) from an actor in
+ * [notifyActorUris] (a followed account with notifications left on), and (c) not
+ * a reply to someone else — a reply notifies only when it targets one of YOUR
+ * posts (`in_reply_to_mine`). The new high-water mark advances to the latest post
+ * seen across the whole page — so a muted or already-seen post never re-triggers.
+ *
+ * Newness is judged by `received_at` (when OUR instance stored the post), not
+ * `published_at`: federation retries deliver posts out of publish order, and a
+ * publish-time high-water silently skips any post that arrives after a
+ * newer-published one. `published_at` remains the fallback for a backend that
+ * predates `received_at`.
  *
  * On the first run ([highWater] is null) nothing is notified — we only record the
  * high-water mark, so enabling the feature doesn't dump the whole backlog.
@@ -72,7 +87,9 @@ fun decideNotifications(
     notifyActorUris: Set<String>,
     highWater: Instant?,
 ): NotifyDecision {
-    val dated = entries.mapNotNull { entry -> parsePublishedAt(entry.publishedAt)?.let { entry to it } }
+    val dated = entries.mapNotNull { entry ->
+        parsePublishedAt(entry.receivedAt ?: entry.publishedAt)?.let { entry to it }
+    }
     val maxSeen = dated.maxOfOrNull { it.second }
     val newHighWater = listOfNotNull(highWater, maxSeen).maxOrNull()
 
@@ -81,7 +98,11 @@ fun decideNotifications(
     }
 
     val toNotify = dated
-        .filter { (entry, published) -> published.isAfter(highWater) && entry.actorUri in notifyActorUris }
+        .filter { (entry, seenAt) ->
+            seenAt.isAfter(highWater) &&
+                entry.actorUri in notifyActorUris &&
+                (entry.inReplyToUri == null || entry.inReplyToMine)
+        }
         .sortedBy { it.second }
         .map { it.first }
     return NotifyDecision(toNotify = toNotify, newHighWater = newHighWater)

--- a/apps/android/app/src/main/java/net/aurboda/ui/screens/AccountScreen.kt
+++ b/apps/android/app/src/main/java/net/aurboda/ui/screens/AccountScreen.kt
@@ -1,8 +1,10 @@
 package net.aurboda.ui.screens
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -22,6 +24,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,7 +34,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import net.aurboda.NotificationWorker
 import net.aurboda.isPostNotificationsEnabled
 import net.aurboda.setPostNotificationsEnabled
@@ -60,6 +67,30 @@ fun AccountScreen(
     val notifyPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted -> if (granted) turnOn() else notifyEnabled = false }
+
+    // The SYSTEM-level grant, re-checked on every resume so returning from the
+    // settings screen (or a fresh grant via the permission dialog) clears the
+    // warning without restarting the app.
+    var systemNotificationsBlocked by remember {
+        mutableStateOf(!NotificationManagerCompat.from(context).areNotificationsEnabled())
+    }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                systemNotificationsBlocked =
+                    !NotificationManagerCompat.from(context).areNotificationsEnabled()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+    val openSystemNotificationSettings = {
+        context.startActivity(
+            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName),
+        )
+    }
 
     val onNotifyToggle = { want: Boolean ->
         if (want) {
@@ -154,6 +185,22 @@ fun AccountScreen(
                 )
             }
             Switch(checked = notifyEnabled, onCheckedChange = onNotifyToggle)
+        }
+
+        // The worker silently skips posting while the SYSTEM permission is off
+        // (areNotificationsEnabled) — without this warning the toggle looks on
+        // while nothing ever arrives, which is exactly how it silently failed
+        // in the field (#1060).
+        if (notifyEnabled && systemNotificationsBlocked) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Notifications are blocked for Aurboda in Android's settings, so none will be shown.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+            OutlinedButton(onClick = openSystemNotificationSettings) {
+                Text("Open notification settings")
+            }
         }
 
         Spacer(modifier = Modifier.height(24.dp))

--- a/apps/android/app/src/test/java/net/aurboda/PostNotificationsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/PostNotificationsTest.kt
@@ -8,8 +8,22 @@ import org.junit.Test
 
 class PostNotificationsTest {
 
-    private fun entry(objectUri: String, actorUri: String, published: String) =
-        TimelineEntry(objectUri = objectUri, actorUri = actorUri, publishedAt = published)
+    private fun entry(
+        objectUri: String,
+        actorUri: String,
+        published: String,
+        receivedAt: String? = null,
+        inReplyToUri: String? = null,
+        inReplyToMine: Boolean = false,
+    ) =
+        TimelineEntry(
+            objectUri = objectUri,
+            actorUri = actorUri,
+            publishedAt = published,
+            receivedAt = receivedAt,
+            inReplyToUri = inReplyToUri,
+            inReplyToMine = inReplyToMine,
+        )
 
     private val alice = "https://mastodon.example/users/alice"
     private val bob = "https://mastodon.example/users/bob"
@@ -38,6 +52,37 @@ class PostNotificationsTest {
 
         assertEquals(listOf("new-alice"), decision.toNotify.map { it.objectUri })
         assertEquals(Instant.parse("2026-07-15T11:00:00Z"), decision.newHighWater)
+    }
+
+    @Test
+    fun `newness is judged by received_at when present (delayed federation arrival still notifies)`() {
+        val hw = Instant.parse("2026-07-15T10:00:00Z")
+        // Published BEFORE the high-water but received after — the exact case a
+        // published-time high-water silently skipped (#1060).
+        val entries = listOf(
+            entry("late", alice, "2026-07-15T09:00:00Z", receivedAt = "2026-07-15T10:05:00Z"),
+        )
+        val decision = decideNotifications(entries, notifyActorUris = setOf(alice), highWater = hw)
+        assertEquals(listOf("late"), decision.toNotify.map { it.objectUri })
+        assertEquals(Instant.parse("2026-07-15T10:05:00Z"), decision.newHighWater)
+    }
+
+    @Test
+    fun `replies to others never notify, replies to your own posts do`() {
+        val hw = Instant.parse("2026-07-15T10:00:00Z")
+        val entries = listOf(
+            entry("reply-other", alice, "2026-07-15T10:30:00Z", inReplyToUri = "https://x.example/1"),
+            entry(
+                "reply-mine",
+                alice,
+                "2026-07-15T10:40:00Z",
+                inReplyToUri = "https://me.example/users/me/feed/abc",
+                inReplyToMine = true,
+            ),
+            entry("top-level", alice, "2026-07-15T10:50:00Z"),
+        )
+        val decision = decideNotifications(entries, notifyActorUris = setOf(alice), highWater = hw)
+        assertEquals(listOf("reply-mine", "top-level"), decision.toNotify.map { it.objectUri })
     }
 
     @Test

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -317,6 +317,7 @@ export {
   type TimelineCursor,
   type TimelineEntryInput,
   type TimelineEntryRecord,
+  type TimelineReplyFilter,
   type UnenrichedTimelineEntry,
   upsertTimelineEntry,
 } from './timeline.ts'

--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -163,6 +163,36 @@ describe('Timeline store integration', () => {
     expect(page3.map((e) => e.object_uri)).toEqual(['https://mastodon.example/notes/1'])
   })
 
+  test('stores in_reply_to_uri and filters replies-to-others per the reply filter (#1060)', async () => {
+    const user = getTestUser()
+    const ownPrefix = `https://aurboda.example/users/${user}/feed/`
+    await upsertTimelineEntry(user, entry(1)) // top-level post
+    await upsertTimelineEntry(user, entry(2, { in_reply_to_uri: 'https://mastodon.example/notes/1' }))
+    const replyToMine = await upsertTimelineEntry(
+      user,
+      entry(3, { in_reply_to_uri: `${ownPrefix}11111111-1111-4111-8111-111111111111` }),
+    )
+    expect(replyToMine.in_reply_to_uri).toBe(`${ownPrefix}11111111-1111-4111-8111-111111111111`)
+
+    // No filter (legacy callers): everything.
+    expect(await listTimelineEntries(user, 10)).toHaveLength(3)
+    // show_replies=false: top-level + the reply to the reader's own post only.
+    const filtered = await listTimelineEntries(user, 10, undefined, {
+      own_object_prefix: ownPrefix,
+      show_replies: false,
+    })
+    expect(filtered.map((r) => r.object_uri)).toEqual([
+      'https://mastodon.example/notes/3',
+      'https://mastodon.example/notes/1',
+    ])
+    // show_replies=true: everything again.
+    const all = await listTimelineEntries(user, 10, undefined, {
+      own_object_prefix: ownPrefix,
+      show_replies: true,
+    })
+    expect(all).toHaveLength(3)
+  })
+
   test('deletes a single entry by object uri + authoring actor (inbound Delete)', async () => {
     const user = getTestUser()
     await upsertTimelineEntry(user, entry(1))

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -23,6 +23,8 @@ export interface TimelineEntryRecord {
   url: string | null
   published_at: Date
   received_at: Date
+  /** The `inReplyTo` object id when the post is a reply, or null for a top-level post. */
+  in_reply_to_uri: string | null
   /** Native structured payload from an Aurboda peer, or null for non-Aurboda posts. */
   structured: FeedStructuredPost | null
   /** Image attachments (rendered chart / route map, or a Mastodon photo), or null. */
@@ -39,6 +41,8 @@ export interface TimelineEntryInput {
   content: string
   url?: string | null
   published_at: Date
+  /** The `inReplyTo` object id when the post is a reply. */
+  in_reply_to_uri?: string | null
   /** Native structured payload fetched from an Aurboda peer on ingest, if any. */
   structured?: FeedStructuredPost | null
   /** Image attachments captured from the delivered Note, if any. */
@@ -52,7 +56,7 @@ export interface TimelineCursor {
 }
 
 const TIMELINE_COLUMNS =
-  'id, object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, received_at, structured, images'
+  'id, object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, received_at, in_reply_to_uri, structured, images'
 
 /**
  * Insert or update a received post by `object_uri`. A re-delivered or edited post
@@ -71,8 +75,8 @@ export const upsertTimelineEntry = async (
   const result = await query<TimelineEntryRecord & { inserted: boolean }>(
     user,
     `INSERT INTO timeline_entry
-       (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, structured, images)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, in_reply_to_uri, structured, images)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
      ON CONFLICT (object_uri)
      DO UPDATE SET actor_uri = EXCLUDED.actor_uri,
                    handle = EXCLUDED.handle,
@@ -81,6 +85,7 @@ export const upsertTimelineEntry = async (
                    content = EXCLUDED.content,
                    url = EXCLUDED.url,
                    published_at = EXCLUDED.published_at,
+                   in_reply_to_uri = EXCLUDED.in_reply_to_uri,
                    -- Keep the last-known structured payload if a refresh/edit
                    -- couldn't re-fetch it (transient enrich failure), rather
                    -- than wiping a working chart.
@@ -100,6 +105,7 @@ export const upsertTimelineEntry = async (
       input.content,
       input.url ?? null,
       input.published_at,
+      input.in_reply_to_uri ?? null,
       input.structured == null ? null : JSON.stringify(input.structured),
       input.images == null ? null : JSON.stringify(input.images),
     ],
@@ -107,23 +113,46 @@ export const upsertTimelineEntry = async (
   return result.rows[0]
 }
 
+/** Reply visibility for a timeline page (from the `timeline_show_replies` setting). */
+export interface TimelineReplyFilter {
+  /** When false, replies to OTHER people's posts are excluded from the page. */
+  show_replies: boolean
+  /**
+   * URI prefix of the reader's OWN post objects (`{origin}/users/{me}/feed/`):
+   * a reply whose target starts with it is a reply to the reader and always
+   * shows. LIKE wildcards in it are escaped here.
+   */
+  own_object_prefix: string
+}
+
+const escapeLike = (s: string): string => s.replaceAll(/[%_\\]/g, (c) => `\\${c}`)
+
 /**
  * A page of the home timeline, newest first. Keyset-paginated: pass the previous
  * page's last `(published_at, id)` as `before` to get the next page. Returns up
- * to `limit` rows.
+ * to `limit` rows. Filtering happens in SQL (not post-hoc) so pages stay full
+ * and cursors stable whatever the reply setting.
  */
 export const listTimelineEntries = async (
   user: string,
   limit: number,
   before?: TimelineCursor,
+  replies?: TimelineReplyFilter,
 ): Promise<TimelineEntryRecord[]> => {
   const result = await query<TimelineEntryRecord>(
     user,
     `SELECT ${TIMELINE_COLUMNS} FROM timeline_entry
      WHERE ($1::timestamptz IS NULL OR (published_at, id) < ($1::timestamptz, $2::uuid))
+       AND ($4::boolean OR in_reply_to_uri IS NULL OR in_reply_to_uri LIKE $5)
      ORDER BY published_at DESC, id DESC
      LIMIT $3`,
-    [before?.published_at ?? null, before?.id ?? null, limit],
+    [
+      before?.published_at ?? null,
+      before?.id ?? null,
+      limit,
+      replies?.show_replies ?? true,
+      replies == null ? '' : `${escapeLike(replies.own_object_prefix)}%`,
+    ],
   )
   return result.rows
 }

--- a/apps/backend/src/db/types.ts
+++ b/apps/backend/src/db/types.ts
@@ -481,6 +481,7 @@ export interface UserSettings {
   manually_approve_followers?: boolean // Hold incoming follows for manual approval (locked account)
   rescue_time_key?: string // RescueTime API key (personal token)
   sex?: BiologicalSex // Biological sex for calorie calculation
+  timeline_show_replies?: boolean // Show followed actors' replies to others as own timeline cards
   item_icons?: Record<string, string> // Unified icon mappings for all timeline items (tags, activities, exercise types)
   tag_icons?: Record<string, string> // Deprecated: tag-only icons (migrated to item_icons)
   food_sensitivity_map?: Record<string, string[]> // Food item name -> sensitivity areas

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -254,7 +254,7 @@ export const registerFeedTools = (server: McpServer, user: string, options: Feed
     'List your home timeline: posts received from the actors you follow, newest first. Pass `cursor` (from a previous call) to page.',
     { ...timelineQuerySchema.shape },
     async ({ cursor, limit }) => {
-      const page = await getTimelinePage(user, limit, cursor)
+      const page = await getTimelinePage(user, limit, cursor, { origin: webHost })
       retroEnrichTimeline?.(user)
       return jsonResponse(page)
     },

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -167,7 +167,9 @@ export const createFeedRouter = (
     validateQuery(timelineQuerySchema),
     async (req, res) => {
       const user = req.user!
-      const { entries, next_cursor } = await getTimelinePage(user, req.query.limit, req.query.cursor)
+      const { entries, next_cursor } = await getTimelinePage(user, req.query.limit, req.query.cursor, {
+        origin: webHost,
+      })
       retroEnrichTimeline?.(user)
       res.json({ entries, next_cursor, success: true })
     },

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -161,6 +161,7 @@ export const tableCreationOrder = [
   'timeline_entry_images',
   'timeline_entry_enrich_attempted',
   'timeline_entry_enrich_attempts',
+  'timeline_entry_reply',
   'timeline_entry_indexes',
   'timeline_entry_unenriched_indexes',
   'profile_avatar',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -338,6 +338,11 @@ export const socialTables: Record<string, string> = {
   timeline_entry_enrich_attempts: `
     ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS enrich_attempts SMALLINT NOT NULL DEFAULT 0
   `,
+  // The inReplyTo object id when the received post is a reply (#1060). NULL for
+  // top-level posts — the timeline query filters replies-to-others by this.
+  timeline_entry_reply: `
+    ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS in_reply_to_uri TEXT
+  `,
   // Timeline ordering / keyset pagination is by (published_at DESC, id DESC).
   timeline_entry_indexes: `
     CREATE INDEX IF NOT EXISTS idx_timeline_entry_published

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -102,6 +102,9 @@ export const noteToTimelineInput = (
     content: sanitizeRemoteHtml(note.content?.toString() ?? ''),
     display_name: author.display_name,
     handle: author.handle,
+    // A reply's target id, so the timeline can filter replies-to-others and
+    // notify only replies the reader is involved in (#1060).
+    in_reply_to_uri: note.replyTargetIds[0]?.href ?? null,
     object_uri: note.id.href,
     published_at: new Date(Math.min(publishedAt.getTime(), now)),
     url: note.url instanceof URL ? note.url.href : note.id.href,

--- a/apps/backend/src/services/settings.ts
+++ b/apps/backend/src/services/settings.ts
@@ -219,6 +219,7 @@ const settingsWithDefaultsSchema = userSettingsResponseSchema.pick({
   sex: true,
   tag_icons: true,
   tag_mappings: true,
+  timeline_show_replies: true,
   training_load: true,
   tz: true,
 })

--- a/apps/backend/src/services/timeline.test.ts
+++ b/apps/backend/src/services/timeline.test.ts
@@ -12,6 +12,7 @@ const record = (over: Partial<TimelineEntryRecord> = {}): TimelineEntryRecord =>
   handle: '@alice@remote.example',
   id: '00000000-0000-0000-0000-000000000001',
   images: null,
+  in_reply_to_uri: null,
   object_uri: 'https://remote.example/notes/1',
   published_at: new Date('2026-07-01T08:00:00.000Z'),
   received_at: new Date('2026-07-01T08:00:05.000Z'),
@@ -21,7 +22,7 @@ const record = (over: Partial<TimelineEntryRecord> = {}): TimelineEntryRecord =>
 })
 
 describe('serializeTimelineEntry', () => {
-  test('maps a stored record to the DTO with an ISO published_at and no received_at', () => {
+  test('maps a stored record to the DTO with ISO timestamps', () => {
     const dto = serializeTimelineEntry(record())
     expect(dto).toEqual({
       actor_uri: 'https://remote.example/users/alice',
@@ -32,10 +33,24 @@ describe('serializeTimelineEntry', () => {
       id: '00000000-0000-0000-0000-000000000001',
       object_uri: 'https://remote.example/notes/1',
       published_at: '2026-07-01T08:00:00.000Z',
+      received_at: '2026-07-01T08:00:05.000Z',
       url: 'https://remote.example/@alice/1',
     })
-    // Ingest-only bookkeeping is not exposed.
-    expect(dto).not.toHaveProperty('received_at')
+    // A top-level post carries no reply fields at all.
+    expect(dto).not.toHaveProperty('in_reply_to_uri')
+  })
+
+  test('marks a reply to the reader’s own post when given the own-object prefix', () => {
+    const reply = record({ in_reply_to_uri: 'https://aurboda.example/users/me/feed/abc' })
+    const mine = serializeTimelineEntry(reply, 'https://aurboda.example/users/me/feed/')
+    expect(mine.in_reply_to_uri).toBe('https://aurboda.example/users/me/feed/abc')
+    expect(mine.in_reply_to_mine).toBe(true)
+
+    const other = serializeTimelineEntry(
+      record({ in_reply_to_uri: 'https://remote.example/notes/9' }),
+      'https://aurboda.example/users/me/feed/',
+    )
+    expect(other.in_reply_to_mine).toBe(false)
   })
 })
 
@@ -51,33 +66,53 @@ describe('getTimelinePage', () => {
 
   test('requests limit + 1 rows and passes a decoded cursor of undefined on the first page', async () => {
     const calls: { limit: number; cursor?: TimelineCursor }[] = []
-    await getTimelinePage('user', 20, undefined, async (_u, limit, cursor) => {
-      calls.push({ cursor, limit })
-      return []
+    await getTimelinePage('user', 20, undefined, {
+      fetchEntries: async (_u, limit, cursor) => {
+        calls.push({ cursor, limit })
+        return []
+      },
     })
     expect(calls).toEqual([{ cursor: undefined, limit: 21 }])
   })
 
+  test('threads the reply filter from settings + origin down to the fetcher', async () => {
+    let seen: unknown
+    await getTimelinePage('freja', 20, undefined, {
+      fetchEntries: async (_u, _l, _c, replies) => {
+        seen = replies
+        return []
+      },
+      loadSettings: async () => ({ timeline_show_replies: false }),
+      origin: 'https://aurboda.example/',
+    })
+    expect(seen).toEqual({
+      own_object_prefix: 'https://aurboda.example/users/freja/feed/',
+      show_replies: false,
+    })
+  })
+
   test('returns no next_cursor when the fetch yields at most `limit` rows', async () => {
-    const page = await getTimelinePage('user', 20, undefined, async () => rows(20))
+    const page = await getTimelinePage('user', 20, undefined, { fetchEntries: async () => rows(20) })
     expect(page.entries).toHaveLength(20)
     expect(page.next_cursor).toBeNull()
   })
 
   test('trims the sentinel row and emits a next_cursor when there are more', async () => {
-    const page = await getTimelinePage('user', 20, undefined, async () => rows(21))
+    const page = await getTimelinePage('user', 20, undefined, { fetchEntries: async () => rows(21) })
     expect(page.entries).toHaveLength(20)
     expect(page.next_cursor).toEqual(expect.any(String))
   })
 
   test('a next_cursor round-trips back to the (published_at, id) of the last returned row', async () => {
-    const first = await getTimelinePage('user', 2, undefined, async () => rows(3))
+    const first = await getTimelinePage('user', 2, undefined, { fetchEntries: async () => rows(3) })
     const lastEntry = first.entries[first.entries.length - 1]
 
     let received: TimelineCursor | undefined
-    await getTimelinePage('user', 2, first.next_cursor ?? undefined, async (_u, _l, cursor) => {
-      received = cursor
-      return []
+    await getTimelinePage('user', 2, first.next_cursor ?? undefined, {
+      fetchEntries: async (_u, _l, cursor) => {
+        received = cursor
+        return []
+      },
     })
     expect(received?.id).toBe(lastEntry.id)
     expect(received?.published_at.toISOString()).toBe(lastEntry.published_at)
@@ -85,9 +120,11 @@ describe('getTimelinePage', () => {
 
   test('treats a malformed cursor as the first page (undefined) rather than throwing', async () => {
     let received: TimelineCursor | undefined = { id: 'sentinel', published_at: new Date(0) }
-    await getTimelinePage('user', 20, 'not-a-valid-cursor!!', async (_u, _l, cursor) => {
-      received = cursor
-      return []
+    await getTimelinePage('user', 20, 'not-a-valid-cursor!!', {
+      fetchEntries: async (_u, _l, cursor) => {
+        received = cursor
+        return []
+      },
     })
     expect(received).toBeUndefined()
   })
@@ -97,9 +134,11 @@ describe('getTimelinePage', () => {
     // it must decode to undefined (first page) rather than reaching the uuid cast.
     const crafted = Buffer.from('12345:not-a-uuid').toString('base64url')
     let received: TimelineCursor | undefined = { id: 'sentinel', published_at: new Date(0) }
-    await getTimelinePage('user', 20, crafted, async (_u, _l, cursor) => {
-      received = cursor
-      return []
+    await getTimelinePage('user', 20, crafted, {
+      fetchEntries: async (_u, _l, cursor) => {
+        received = cursor
+        return []
+      },
     })
     expect(received).toBeUndefined()
   })

--- a/apps/backend/src/services/timeline.ts
+++ b/apps/backend/src/services/timeline.ts
@@ -9,10 +9,11 @@
  */
 import type { TimelineEntry } from '@aurboda/api-spec'
 
-import type { TimelineCursor, TimelineEntryRecord } from '../db/index.ts'
+import type { TimelineCursor, TimelineEntryRecord, TimelineReplyFilter } from '../db/index.ts'
 
 import { listTimelineEntries } from '../db/index.ts'
 import { decodeKeysetCursor, encodeKeysetCursor } from './keyset-cursor.ts'
+import { getSettings } from './settings.ts'
 
 /** Decode an opaque cursor, or undefined if it's missing/malformed (→ first page). */
 const decodeCursor = (cursor: string | undefined): TimelineCursor | undefined => {
@@ -20,16 +21,27 @@ const decodeCursor = (cursor: string | undefined): TimelineCursor | undefined =>
   return decoded && { id: decoded.id, published_at: decoded.ts }
 }
 
-export const serializeTimelineEntry = (record: TimelineEntryRecord): TimelineEntry => ({
+export const serializeTimelineEntry = (
+  record: TimelineEntryRecord,
+  /** URI prefix of the reader's own post objects, to mark replies-to-me. */
+  ownObjectPrefix?: string,
+): TimelineEntry => ({
   actor_uri: record.actor_uri,
   avatar_url: record.avatar_url,
   content: record.content,
   display_name: record.display_name,
   handle: record.handle,
   id: record.id,
+  ...(record.in_reply_to_uri == null
+    ? {}
+    : {
+        in_reply_to_mine: ownObjectPrefix != null && record.in_reply_to_uri.startsWith(ownObjectPrefix),
+        in_reply_to_uri: record.in_reply_to_uri,
+      }),
   ...(record.images == null || record.images.length === 0 ? {} : { images: record.images }),
   object_uri: record.object_uri,
   published_at: record.published_at.toISOString(),
+  received_at: record.received_at.toISOString(),
   ...(record.structured == null ? {} : { structured: record.structured }),
   url: record.url,
 })
@@ -39,7 +51,24 @@ export type TimelineFetcher = (
   user: string,
   limit: number,
   cursor?: TimelineCursor,
+  replies?: TimelineReplyFilter,
 ) => Promise<TimelineEntryRecord[]>
+
+/** The URI prefix of a user's own post objects on this instance. */
+export const ownObjectPrefix = (origin: string, user: string): string =>
+  `${origin.replace(/\/+$/, '')}/users/${encodeURIComponent(user)}/feed/`
+
+export interface TimelinePageOpts {
+  /**
+   * Web origin. When set, the page applies the `timeline_show_replies` setting
+   * (replies to others hidden unless enabled; replies to the reader's own posts
+   * always shown, marked `in_reply_to_mine`). Absent: no reply filtering.
+   */
+  origin?: string
+  fetchEntries?: TimelineFetcher
+  /** Injected settings lookup (defaults to the real one) for offline tests. */
+  loadSettings?: (user: string) => Promise<{ timeline_show_replies?: boolean } | null>
+}
 
 /**
  * One page of the home timeline (newest first) plus the cursor for the next page
@@ -51,14 +80,22 @@ export const getTimelinePage = async (
   user: string,
   limit: number,
   cursor?: string,
-  fetchEntries: TimelineFetcher = listTimelineEntries,
+  opts: TimelinePageOpts = {},
 ): Promise<{ entries: TimelineEntry[]; next_cursor: string | null }> => {
-  const rows = await fetchEntries(user, limit + 1, decodeCursor(cursor))
+  const fetchEntries = opts.fetchEntries ?? listTimelineEntries
+  let replies: TimelineReplyFilter | undefined
+  let prefix: string | undefined
+  if (opts.origin != null) {
+    const settings = await (opts.loadSettings ?? getSettings)(user).catch(() => null)
+    prefix = ownObjectPrefix(opts.origin, user)
+    replies = { own_object_prefix: prefix, show_replies: settings?.timeline_show_replies === true }
+  }
+  const rows = await fetchEntries(user, limit + 1, decodeCursor(cursor), replies)
   const hasMore = rows.length > limit
   const page = hasMore ? rows.slice(0, limit) : rows
   const last = page[page.length - 1]
   return {
-    entries: page.map(serializeTimelineEntry),
+    entries: page.map((row) => serializeTimelineEntry(row, prefix)),
     next_cursor: hasMore && last ? encodeKeysetCursor(last.published_at, last.id) : null,
   }
 }

--- a/apps/web/src/pages/Feed/FeedPostCard.css
+++ b/apps/web/src/pages/Feed/FeedPostCard.css
@@ -43,6 +43,12 @@
   color: #6b7280;
 }
 
+.feed-post-reply-marker {
+  font-size: 0.75rem;
+  color: #6b7280;
+  font-style: italic;
+}
+
 .feed-post-handle a,
 .feed-post-name a {
   color: inherit;

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -71,6 +71,11 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
               <time title={new Date(entry.published_at).toLocaleString()}>{when}</time>
             )}
           </span>
+          {entry.in_reply_to_uri != null && (
+            <span class="feed-post-reply-marker">
+              ↩ {entry.in_reply_to_mine ? 'replied to you' : 'a reply'}
+            </span>
+          )}
         </div>
       </header>
 

--- a/apps/web/src/pages/Settings/index.tsx
+++ b/apps/web/src/pages/Settings/index.tsx
@@ -29,6 +29,7 @@ export function Settings() {
   const [sex, setSex] = useState<BiologicalSex | null>(null)
   const [hrZones, setHrZones] = useState<HrZoneThresholds | null>(null)
   const [manualApproval, setManualApproval] = useState(false)
+  const [showReplies, setShowReplies] = useState(false)
 
   // Save status for each section
   const [personalInfoStatus, setPersonalInfoStatus] = useState<SaveStatus>({ status: 'idle' })
@@ -41,6 +42,7 @@ export function Settings() {
     setSex(userSettings?.sex ?? null)
     setHrZones(userSettings?.hr_zone_start ?? null)
     setManualApproval(userSettings?.manually_approve_followers ?? false)
+    setShowReplies(userSettings?.timeline_show_replies ?? false)
   }
 
   // Track if form has been initialized
@@ -125,6 +127,12 @@ export function Settings() {
     const checked = (e.target as HTMLInputElement).checked
     setManualApproval(checked)
     saveSection({ manually_approve_followers: checked }, setFollowersStatus)
+  }
+
+  const handleShowRepliesChange = (e: Event) => {
+    const checked = (e.target as HTMLInputElement).checked
+    setShowReplies(checked)
+    saveSection({ timeline_show_replies: checked }, setFollowersStatus)
   }
 
   if (!isLoggedIn) {
@@ -232,6 +240,17 @@ export function Settings() {
             When on, incoming follows become requests you approve or reject, and only approved followers see
             your <code>followers</code>-only posts. When off (the default), anyone can follow you
             automatically.
+          </p>
+        </div>
+        <div class="form-field">
+          <label class="checkbox-field">
+            <input type="checkbox" checked={showReplies} onChange={handleShowRepliesChange} />
+            <span>Show replies in your timeline</span>
+          </label>
+          <p class="field-description">
+            When on, replies that people you follow write to <em>other</em> people show as their own
+            timeline cards. When off (the default), you see their top-level posts only — replies to your
+            own posts always show either way.
           </p>
         </div>
       </SettingsSection>

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -39,12 +39,18 @@ A native background poller (`NotificationWorker`, a periodic WorkManager job)
 notifies the user when accounts they follow post to their home timeline. Each
 run fetches `/feed/following` and `/feed/timeline`, then the pure, unit-tested
 `decideNotifications` (`PostNotifications.kt`) picks which posts to notify: those
-newer than a stored high-water mark and from a followed actor whose server-side
-`notify_on_post` flag is on (toggled per-account on the web Feed page). The first
+newer than a stored high-water mark (judged by `received_at` — when the server
+stored the post — since `published_at` arrives out of order after federation
+retries), from a followed actor whose server-side `notify_on_post` flag is on
+(toggled per-account on the web Feed page), and not a reply to someone else
+(a reply notifies only when it targets one of your own posts, #1060). The first
 run only records the high-water mark, so enabling the feature doesn't dump the
 backlog. The user opts in with the **"Notify me about new posts"** switch on the
 Account screen, which requests `POST_NOTIFICATIONS` (Android 13+) and
-schedules/cancels the worker; tapping a notification opens the Feed tab.
+schedules/cancels the worker; tapping a notification opens the Feed tab. When
+the toggle is on but Android's app-level notification permission is off (the
+worker would silently skip posting), the Account screen shows a warning with a
+button into the system notification settings, re-checked on every resume.
 
 ## Embedded web views
 

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -222,6 +222,16 @@ bell in the web Following panel (or the `set_following_notify` MCP tool / `PATCH
 /feed/following/:id`). It controls whether the Android app raises a notification for that
 actor's new home-timeline posts; muting is preserved across a re-follow.
 
+**Replies** (#1060): ingest stores a received Note's `inReplyTo` id as
+`timeline_entry.in_reply_to_uri`. The timeline exposes it (plus `in_reply_to_mine`, true when
+the target is one of the reader's own posts) and filters by the **`timeline_show_replies`**
+user setting: off (the default) hides followed actors' replies to *other* people from the
+home timeline — replies to your own posts always show, marked "replied to you" on the card.
+The Android notifier follows the same involvement rule: new top-level posts notify, replies
+only when they target one of your posts. Entries also expose **`received_at`** (when this
+instance stored the post) — the notifier's high-water mark, since `published_at` can arrive
+out of order after federation retries.
+
 The actor advertises a **following collection** (`/users/<username>/following`) listing only
 _accepted_ follows (a pending follow isn't a confirmed relationship yet). The followee's
 inbox URIs are internal delivery details and are never exposed on the owner-facing API.

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -645,12 +645,23 @@ export const timelineEntrySchema = z
     display_name: z.string().nullable().meta({ description: "The author's display name, if known" }),
     handle: z.string().nullable().meta({ description: "The author's `@user@host` handle, if known" }),
     id: z.string().uuid().meta({ description: 'Local id of the timeline entry' }),
+    in_reply_to_mine: z.boolean().optional().meta({
+      description:
+        'True when this is a reply to one of YOUR posts (present only on replies) — such replies always show and notify regardless of the `timeline_show_replies` setting',
+    }),
+    in_reply_to_uri: z.string().nullable().optional().meta({
+      description: 'The `inReplyTo` object id when this post is a reply, else absent/null',
+    }),
     images: z.array(timelineImageSchema).optional().meta({
       description:
         'Image attachments (e.g. a rendered chart or route map), shown when the post carries no native structured chart.',
     }),
     object_uri: z.string().meta({ description: "The remote post's canonical id" }),
     published_at: iso8601DateTimeSchema.meta({ description: 'When the post was published (ISO 8601)' }),
+    received_at: iso8601DateTimeSchema.meta({
+      description:
+        'When this instance received the post (ISO 8601). Monotonic per timeline — the correct high-water mark for "what have I already seen", since `published_at` can arrive out of order after federation retries.',
+    }),
     structured: feedStructuredPostSchema.optional().meta({
       description:
         'Native structured data (an activity share’s typed metrics/series, or an article’s title + resolved blocks), present only for posts from Aurboda instances — drives a native render instead of the HTML.',

--- a/packages/api-spec/src/schemas/settings.ts
+++ b/packages/api-spec/src/schemas/settings.ts
@@ -217,6 +217,10 @@ export const updateSettingsInputSchema = z
     rescue_time_key: rescueTimeKeySchema.nullable().optional().meta({
       description: 'RescueTime API key (set to null to clear)',
     }),
+    timeline_show_replies: z.boolean().nullable().optional().meta({
+      description:
+        'When true, replies from followed actors to OTHER people show as their own home-timeline cards; when false (default), only their top-level posts and replies to your own posts appear (set to null to reset to the default).',
+    }),
     sensitivity_areas: sensitivityAreasSchema.nullable().optional().meta({
       description: 'Sensitivity areas to track in meals (set to null to clear)',
     }),
@@ -290,6 +294,10 @@ export const userSettingsResponseSchema = baseResponseSchema
       .meta({ description: 'Whether Oura OAuth is configured on server' }),
     oura_connected: z.boolean().default(false).meta({ description: 'Whether Oura is connected via OAuth' }),
     rescue_time_key: z.string().nullable().default(null).meta({ description: 'RescueTime API key' }),
+    timeline_show_replies: z.boolean().default(false).meta({
+      description:
+        "Whether followed actors' replies to other people show as their own home-timeline cards (replies to your own posts always show)",
+    }),
     strava_connected: z
       .boolean()
       .default(false)


### PR DESCRIPTION
Closes #1060. Three gaps from following Mastodon publishers (Fredrik's report):

## 1. Replies as their own cards — now a setting

Ingest discarded `inReplyTo` entirely, so followed actors' replies to strangers landed as ordinary cards with no way to filter. Now:

- `timeline_entry.in_reply_to_uri` stored at ingest (additive column + `tableCreationOrder` entry, schema-guard test covers it).
- New **`timeline_show_replies`** user setting (default **off**): replies to *other* people are hidden from the home timeline; **replies to your own posts always show**, marked "↩ replied to you" on the card. Filtering happens in SQL so pages stay full and cursors stable; the own-post match is a LIKE against `{origin}/users/{me}/feed/` with wildcards escaped.
- Same filter on MCP `list_timeline`; settings parity via `updateUserSettingsBodySchema` (REST + MCP + web toggle under Feed & Followers); Kotlin models regenerated.

## 2. Notifications: reply-aware and race-free

- `TimelineEntry` now exposes **`received_at`** and the notifier's high-water mark uses it (fallback `published_at` for a rolling deploy). The old publish-time high-water **silently skipped any post that arrived after a newer-published one** — federation retries make that routine. Unit test pins the exact scenario.
- Replies notify only when `in_reply_to_mine` — new posts always, per Mastodon-like involvement. (Per-thread notification subscriptions are follow-up scope, tracked in #1060's plan.)

## 3. The silent-permission trap (Fredrik's actual root cause)

The in-app toggle showed ON while Android's app-level notification permission was off, and the worker **silently skipped** posting (`areNotificationsEnabled()` check). The Account screen now shows a warning with an "Open notification settings" button whenever the toggle is on but the system permission is off, re-checked on every resume so it clears after granting.

Tests: 3032 backend (unit + integration, incl. new SQL-filter integration case and reply/`received_at` service tests), 586 web, Android unit tests green (`compileDebugKotlin` + `testDebugUnitTest` locally); whole-monorepo check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwoP1SqJhHgHiEEoEQtUjT
