### PR TITLE
feat(feed): mentions + stranger involvement, expand replies, reply backfill, bell reconciliation (#1060 r2)

### DIFF
--- a/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
+++ b/apps/android/app/src/main/java/net/aurboda/MainActivity.kt
@@ -169,6 +169,10 @@ class MainActivity : ComponentActivity() {
     val link = deepLinkFrom(intent)
     setContent {
       AurbodaAppShell {
+        // Reconcile the Feed page's per-account notification bells with the
+        // device: request the permission + start the poller when bells are on
+        // but no explicit choice was ever made (#1060).
+        AutoEnablePostNotifications()
         AurbodaApp(initialTab = link?.tab, initialMorePath = link?.morePath, deepLinkEvent = runningDeepLink)
       }
     }

--- a/apps/android/app/src/main/java/net/aurboda/PostNotificationAutoEnable.kt
+++ b/apps/android/app/src/main/java/net/aurboda/PostNotificationAutoEnable.kt
@@ -1,0 +1,62 @@
+package net.aurboda
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Launch-time reconciliation of the per-account notification bells with the
+ * device (#1060): the bells on the Feed page set the server-side
+ * `notify_on_post` flags, but they can only ever produce a notification when
+ * the app's poller is on AND Android's permission is granted — without this,
+ * bells silently lie to the user.
+ *
+ * If the user has never made an explicit on/off choice and any followed
+ * account has its bell on, this enables the poller, requesting
+ * `POST_NOTIFICATIONS` when needed. An explicit "off" on the Account screen is
+ * never overridden (the recorded choice guards it), and a denied permission
+ * request records "off" so the user isn't re-prompted every launch — the
+ * Account screen's warning takes over from there.
+ */
+@Composable
+fun AutoEnablePostNotifications() {
+    val context = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        // Either way the choice is now recorded; only a grant starts the poller.
+        setPostNotificationsEnabled(context, granted)
+        if (granted) NotificationWorker.schedule(context)
+    }
+    LaunchedEffect(Unit) {
+        if (isPostNotificationsChoiceMade(context)) return@LaunchedEffect
+        val credentials = CredentialsManager.getCredentials(context) ?: return@LaunchedEffect
+        val anyBellOn = withContext(Dispatchers.IO) {
+            val client = syncHttpClient()
+            try {
+                fetchFollowingList(client, credentials.apiUrl, credentials.authToken)
+                    ?.following?.any { it.notifyOnPost } == true
+            } finally {
+                client.close()
+            }
+        }
+        if (!anyBellOn) return@LaunchedEffect
+        val needsPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        if (needsPermission) {
+            launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            setPostNotificationsEnabled(context, true)
+            NotificationWorker.schedule(context)
+        }
+    }
+}

--- a/apps/android/app/src/main/java/net/aurboda/PostNotificationPrefs.kt
+++ b/apps/android/app/src/main/java/net/aurboda/PostNotificationPrefs.kt
@@ -18,6 +18,14 @@ private fun postNotifPrefs(context: Context) =
 fun isPostNotificationsEnabled(context: Context): Boolean =
     postNotifPrefs(context).getBoolean(POST_NOTIF_ENABLED_KEY, false)
 
+/**
+ * Whether an on/off choice has ever been recorded (by the user's toggle or a
+ * completed auto-enable). Guards the launch-time auto-enable so it never
+ * overrides an explicit "off".
+ */
+fun isPostNotificationsChoiceMade(context: Context): Boolean =
+    postNotifPrefs(context).contains(POST_NOTIF_ENABLED_KEY)
+
 fun setPostNotificationsEnabled(context: Context, enabled: Boolean) {
     postNotifPrefs(context).edit().putBoolean(POST_NOTIF_ENABLED_KEY, enabled).apply()
 }

--- a/apps/android/app/src/main/java/net/aurboda/PostNotifications.kt
+++ b/apps/android/app/src/main/java/net/aurboda/PostNotifications.kt
@@ -28,6 +28,8 @@ data class TimelineEntry(
     // the reader's own posts (always notified — you're involved).
     @SerialName("in_reply_to_uri") val inReplyToUri: String? = null,
     @SerialName("in_reply_to_mine") val inReplyToMine: Boolean = false,
+    // A Mention of the reader — involvement, like a reply to their own post.
+    @SerialName("mentions_me") val mentionsMe: Boolean = false,
 ) {
     /** Best available human name for the notification title. */
     val authorLabel: String get() = displayName ?: handle ?: actorUri
@@ -67,11 +69,14 @@ fun parsePublishedAt(value: String): Instant? =
 /**
  * Decide which timeline posts to notify about.
  *
- * Notify a post when it is (a) newer than [highWater], (b) from an actor in
- * [notifyActorUris] (a followed account with notifications left on), and (c) not
- * a reply to someone else — a reply notifies only when it targets one of YOUR
- * posts (`in_reply_to_mine`). The new high-water mark advances to the latest post
- * seen across the whole page — so a muted or already-seen post never re-triggers.
+ * A post the reader is INVOLVED in — a reply to one of their own posts, or a
+ * Mention of them — notifies whoever wrote it (its author may not be followed at
+ * all: a stranger's reply/mention reaches the timeline through the inbox's
+ * involvement branch). Any other post notifies when it is (a) not a reply to
+ * someone else, and (b) from an actor in [notifyActorUris] (a followed account
+ * with notifications left on). Everything is gated on being newer than
+ * [highWater]; the new high-water mark advances to the latest post seen across
+ * the whole page — so a muted or already-seen post never re-triggers.
  *
  * Newness is judged by `received_at` (when OUR instance stored the post), not
  * `published_at`: federation retries deliver posts out of publish order, and a
@@ -99,9 +104,9 @@ fun decideNotifications(
 
     val toNotify = dated
         .filter { (entry, seenAt) ->
+            val involved = entry.inReplyToMine || entry.mentionsMe
             seenAt.isAfter(highWater) &&
-                entry.actorUri in notifyActorUris &&
-                (entry.inReplyToUri == null || entry.inReplyToMine)
+                (involved || (entry.inReplyToUri == null && entry.actorUri in notifyActorUris))
         }
         .sortedBy { it.second }
         .map { it.first }

--- a/apps/android/app/src/test/java/net/aurboda/PostNotificationsTest.kt
+++ b/apps/android/app/src/test/java/net/aurboda/PostNotificationsTest.kt
@@ -15,6 +15,7 @@ class PostNotificationsTest {
         receivedAt: String? = null,
         inReplyToUri: String? = null,
         inReplyToMine: Boolean = false,
+        mentionsMe: Boolean = false,
     ) =
         TimelineEntry(
             objectUri = objectUri,
@@ -23,6 +24,7 @@ class PostNotificationsTest {
             receivedAt = receivedAt,
             inReplyToUri = inReplyToUri,
             inReplyToMine = inReplyToMine,
+            mentionsMe = mentionsMe,
         )
 
     private val alice = "https://mastodon.example/users/alice"
@@ -83,6 +85,28 @@ class PostNotificationsTest {
         )
         val decision = decideNotifications(entries, notifyActorUris = setOf(alice), highWater = hw)
         assertEquals(listOf("reply-mine", "top-level"), decision.toNotify.map { it.objectUri })
+    }
+
+    @Test
+    fun `involvement notifies even from actors outside the notify set`() {
+        val hw = Instant.parse("2026-07-15T10:00:00Z")
+        val stranger = "https://elsewhere.example/users/stranger"
+        val entries = listOf(
+            // A stranger's reply to MY post (admitted by the inbox involvement branch).
+            entry(
+                "stranger-reply",
+                stranger,
+                "2026-07-15T10:10:00Z",
+                inReplyToUri = "https://me.example/users/me/feed/abc",
+                inReplyToMine = true,
+            ),
+            // A stranger mentioning me in a top-level post.
+            entry("stranger-mention", stranger, "2026-07-15T10:20:00Z", mentionsMe = true),
+            // A stranger's plain post never notifies (and never reaches the timeline anyway).
+            entry("stranger-plain", stranger, "2026-07-15T10:30:00Z"),
+        )
+        val decision = decideNotifications(entries, notifyActorUris = setOf(alice), highWater = hw)
+        assertEquals(listOf("stranger-reply", "stranger-mention"), decision.toNotify.map { it.objectUri })
     }
 
     @Test

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -42,11 +42,13 @@ import {
   insertPlace,
   insertRawRecord,
   insertTimeSeries,
+  listReplyUncheckedEntries,
   listUnenrichedAurbodaEntries,
   loginToUserDb,
   markEnrichTransientFailure,
   openTimelineChannel,
   resolveOrCreateActivityType,
+  setTimelineEntryReplyInfo,
   setTimelineEntryStructured,
   softDeleteSupersededLocations,
   updateDetectedLocation,
@@ -104,11 +106,16 @@ import { createInvitationAuth } from './services/invitation.ts'
 import { getPlaceVisits } from './services/locations.ts'
 import { createPgBoss } from './services/pg-boss.ts'
 import { installProcessGuards } from './services/process-guards.ts'
+import { safeFetchGet } from './services/safe-fetch.ts'
 import { initSentry, Sentry } from './services/sentry.ts'
 import { createStravaQueue, type StravaQueue } from './services/strava-queue.ts'
 import { createSyncProvider } from './services/sync-provider.ts'
 import { createTimelineHub } from './services/timeline-hub.ts'
-import { type RetroEnrichTrigger, retroEnrichTimelineEntries } from './services/timeline-retro-enrich.ts'
+import {
+  backfillReplyLinks,
+  type RetroEnrichTrigger,
+  retroEnrichTimelineEntries,
+} from './services/timeline-retro-enrich.ts'
 import { createWebAuthnService } from './services/webauthn.ts'
 
 /** Grace period for in-flight requests before sockets are forced closed. */
@@ -385,13 +392,33 @@ const main = async () => {
   const retroEnrichTimeline: RetroEnrichTrigger = (user) => {
     if (retroInFlight.has(user)) return
     retroInFlight.add(user)
-    void retroEnrichTimelineEntries(user, {
+    const structuredPass = retroEnrichTimelineEntries(user, {
       enrich: retroEnricher,
       listUnenriched: listUnenrichedAurbodaEntries,
       recordTransientFailure: markEnrichTransientFailure,
       save: setTimelineEntryStructured,
     })
-      .catch((err: unknown) => console.warn(`⚠️ timeline retro-enrichment failed for ${user}:`, err))
+    // Reply/Mention backfill for entries ingested before #1060 tracked them —
+    // re-fetches a few objects per read so legacy replies stop rendering as
+    // top-level cards.
+    const replyPass = backfillReplyLinks(user, `${webHost.replace(/\/+$/, '')}/users/${user}`, {
+      fetchObject: async (objectUri) =>
+        (
+          await safeFetchGet(objectUri, {
+            headers: { Accept: 'application/activity+json, application/ld+json; q=0.9' },
+          }).catch(() => null)
+        )?.data ?? null,
+      listUnchecked: listReplyUncheckedEntries,
+      saveReplyInfo: setTimelineEntryReplyInfo,
+    })
+    void Promise.allSettled([structuredPass, replyPass])
+      .then((results) => {
+        for (const r of results) {
+          if (r.status === 'rejected') {
+            console.warn(`⚠️ timeline retro pass failed for ${user}:`, r.reason)
+          }
+        }
+      })
       .finally(() => retroInFlight.delete(user))
   }
   const onDeliverError = (op: string, user: string, postId: string) => (err: unknown) =>

--- a/apps/backend/src/api.ts
+++ b/apps/backend/src/api.ts
@@ -48,6 +48,7 @@ import {
   markEnrichTransientFailure,
   openTimelineChannel,
   resolveOrCreateActivityType,
+  markTimelineEntryReplyChecked,
   setTimelineEntryReplyInfo,
   setTimelineEntryStructured,
   softDeleteSupersededLocations,
@@ -409,6 +410,7 @@ const main = async () => {
           }).catch(() => null)
         )?.data ?? null,
       listUnchecked: listReplyUncheckedEntries,
+      markChecked: markTimelineEntryReplyChecked,
       saveReplyInfo: setTimelineEntryReplyInfo,
     })
     void Promise.allSettled([structuredPass, replyPass])

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -315,6 +315,7 @@ export {
   listTimelineEntries,
   listUnenrichedAurbodaEntries,
   markEnrichTransientFailure,
+  markTimelineEntryReplyChecked,
   setTimelineEntryReplyInfo,
   setTimelineEntryStructured,
   type TimelineCursor,

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -310,9 +310,12 @@ export {
 export {
   deleteTimelineEntriesByActor,
   deleteTimelineEntryByUri,
+  getTimelineEntryById,
+  listReplyUncheckedEntries,
   listTimelineEntries,
   listUnenrichedAurbodaEntries,
   markEnrichTransientFailure,
+  setTimelineEntryReplyInfo,
   setTimelineEntryStructured,
   type TimelineCursor,
   type TimelineEntryInput,

--- a/apps/backend/src/db/timeline.integration.test.ts
+++ b/apps/backend/src/db/timeline.integration.test.ts
@@ -5,12 +5,16 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
  * actors), including keyset pagination by (published_at DESC, id DESC).
  */
 import { cleanTestDb, getTestUser, startTestDb, stopTestDb } from '../test/db-test-helper.ts'
+import { query } from './connection.ts'
 import {
   deleteTimelineEntriesByActor,
   deleteTimelineEntryByUri,
+  getTimelineEntryById,
+  listReplyUncheckedEntries,
   listTimelineEntries,
   listUnenrichedAurbodaEntries,
   markEnrichTransientFailure,
+  setTimelineEntryReplyInfo,
   setTimelineEntryStructured,
   type TimelineEntryInput,
   upsertTimelineEntry,
@@ -191,6 +195,45 @@ describe('Timeline store integration', () => {
       show_replies: true,
     })
     expect(all).toHaveLength(3)
+  })
+
+  test('a mentioned post stays visible with replies hidden; getTimelineEntryById resolves (#1060)', async () => {
+    const user = getTestUser()
+    const ownPrefix = `https://aurboda.example/users/${user}/feed/`
+    const mention = await upsertTimelineEntry(
+      user,
+      entry(1, { in_reply_to_uri: 'https://mastodon.example/notes/root', mentions_me: true }),
+    )
+    await upsertTimelineEntry(user, entry(2, { in_reply_to_uri: 'https://mastodon.example/notes/root' }))
+    const filtered = await listTimelineEntries(user, 10, undefined, {
+      own_object_prefix: ownPrefix,
+      show_replies: false,
+    })
+    expect(filtered.map((r) => r.object_uri)).toEqual(['https://mastodon.example/notes/1'])
+    expect(filtered[0].mentions_me).toBe(true)
+
+    const byId = await getTimelineEntryById(user, mention.id)
+    expect(byId?.object_uri).toBe('https://mastodon.example/notes/1')
+    expect(await getTimelineEntryById(user, '00000000-0000-4000-8000-000000000000')).toBeNull()
+  })
+
+  test('reply backfill: fresh ingests are stamped, legacy rows are listed and updatable (#1060)', async () => {
+    const user = getTestUser()
+    // A fresh ingest stamps reply_checked_at, so it is never a backfill candidate.
+    await upsertTimelineEntry(user, entry(1))
+    expect(await listReplyUncheckedEntries(user, 10)).toEqual([])
+
+    // Simulate a legacy (pre-#1060) row by clearing the stamp.
+    const legacy = await upsertTimelineEntry(user, entry(2))
+    await query(user, `UPDATE timeline_entry SET reply_checked_at = NULL WHERE id = $1`, [legacy.id])
+    const candidates = await listReplyUncheckedEntries(user, 10)
+    expect(candidates).toEqual([{ id: legacy.id, object_uri: 'https://mastodon.example/notes/2' }])
+
+    await setTimelineEntryReplyInfo(user, legacy.id, 'https://mastodon.example/notes/root', true)
+    const updated = await getTimelineEntryById(user, legacy.id)
+    expect(updated?.in_reply_to_uri).toBe('https://mastodon.example/notes/root')
+    expect(updated?.mentions_me).toBe(true)
+    expect(await listReplyUncheckedEntries(user, 10)).toEqual([])
   })
 
   test('deletes a single entry by object uri + authoring actor (inbound Delete)', async () => {

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -25,6 +25,8 @@ export interface TimelineEntryRecord {
   received_at: Date
   /** The `inReplyTo` object id when the post is a reply, or null for a top-level post. */
   in_reply_to_uri: string | null
+  /** Whether the post carries a Mention tag for the timeline owner. */
+  mentions_me: boolean
   /** Native structured payload from an Aurboda peer, or null for non-Aurboda posts. */
   structured: FeedStructuredPost | null
   /** Image attachments (rendered chart / route map, or a Mastodon photo), or null. */
@@ -43,6 +45,8 @@ export interface TimelineEntryInput {
   published_at: Date
   /** The `inReplyTo` object id when the post is a reply. */
   in_reply_to_uri?: string | null
+  /** Whether the post carries a Mention tag for the timeline owner. */
+  mentions_me?: boolean
   /** Native structured payload fetched from an Aurboda peer on ingest, if any. */
   structured?: FeedStructuredPost | null
   /** Image attachments captured from the delivered Note, if any. */
@@ -56,7 +60,7 @@ export interface TimelineCursor {
 }
 
 const TIMELINE_COLUMNS =
-  'id, object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, received_at, in_reply_to_uri, structured, images'
+  'id, object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, received_at, in_reply_to_uri, mentions_me, structured, images'
 
 /**
  * Insert or update a received post by `object_uri`. A re-delivered or edited post
@@ -75,8 +79,8 @@ export const upsertTimelineEntry = async (
   const result = await query<TimelineEntryRecord & { inserted: boolean }>(
     user,
     `INSERT INTO timeline_entry
-       (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, in_reply_to_uri, structured, images)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       (object_uri, actor_uri, handle, display_name, avatar_url, content, url, published_at, in_reply_to_uri, mentions_me, reply_checked_at, structured, images)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), $11, $12)
      ON CONFLICT (object_uri)
      DO UPDATE SET actor_uri = EXCLUDED.actor_uri,
                    handle = EXCLUDED.handle,
@@ -86,6 +90,8 @@ export const upsertTimelineEntry = async (
                    url = EXCLUDED.url,
                    published_at = EXCLUDED.published_at,
                    in_reply_to_uri = EXCLUDED.in_reply_to_uri,
+                   mentions_me = EXCLUDED.mentions_me,
+                   reply_checked_at = NOW(),
                    -- Keep the last-known structured payload if a refresh/edit
                    -- couldn't re-fetch it (transient enrich failure), rather
                    -- than wiping a working chart.
@@ -106,6 +112,7 @@ export const upsertTimelineEntry = async (
       input.url ?? null,
       input.published_at,
       input.in_reply_to_uri ?? null,
+      input.mentions_me ?? false,
       input.structured == null ? null : JSON.stringify(input.structured),
       input.images == null ? null : JSON.stringify(input.images),
     ],
@@ -143,7 +150,7 @@ export const listTimelineEntries = async (
     user,
     `SELECT ${TIMELINE_COLUMNS} FROM timeline_entry
      WHERE ($1::timestamptz IS NULL OR (published_at, id) < ($1::timestamptz, $2::uuid))
-       AND ($4::boolean OR in_reply_to_uri IS NULL OR in_reply_to_uri LIKE $5)
+       AND ($4::boolean OR in_reply_to_uri IS NULL OR mentions_me OR in_reply_to_uri LIKE $5)
      ORDER BY published_at DESC, id DESC
      LIMIT $3`,
     [
@@ -155,6 +162,54 @@ export const listTimelineEntries = async (
     ],
   )
   return result.rows
+}
+
+/** One timeline entry by its local id, or null. */
+export const getTimelineEntryById = async (user: string, id: string): Promise<TimelineEntryRecord | null> => {
+  const result = await query<TimelineEntryRecord>(
+    user,
+    `SELECT ${TIMELINE_COLUMNS} FROM timeline_entry WHERE id = $1`,
+    [id],
+  )
+  return result.rows[0] ?? null
+}
+
+/** A legacy entry whose reply/Mention state is unknown (pre-#1060 ingest). */
+export interface ReplyUncheckedEntry {
+  id: string
+  object_uri: string
+}
+
+/** Newest legacy entries still lacking a reply check, for the lazy backfill. */
+export const listReplyUncheckedEntries = async (
+  user: string,
+  limit: number,
+): Promise<ReplyUncheckedEntry[]> => {
+  const result = await query<ReplyUncheckedEntry>(
+    user,
+    `SELECT id, object_uri FROM timeline_entry
+     WHERE reply_checked_at IS NULL
+     ORDER BY received_at DESC
+     LIMIT $1`,
+    [limit],
+  )
+  return result.rows
+}
+
+/** Store a backfilled reply/Mention state and stamp the entry checked. */
+export const setTimelineEntryReplyInfo = async (
+  user: string,
+  id: string,
+  inReplyToUri: string | null,
+  mentionsMe: boolean,
+): Promise<void> => {
+  await query(
+    user,
+    `UPDATE timeline_entry
+     SET in_reply_to_uri = $2, mentions_me = $3, reply_checked_at = NOW()
+     WHERE id = $1`,
+    [id, inReplyToUri, mentionsMe],
+  )
 }
 
 /**

--- a/apps/backend/src/db/timeline.ts
+++ b/apps/backend/src/db/timeline.ts
@@ -213,6 +213,15 @@ export const setTimelineEntryReplyInfo = async (
 }
 
 /**
+ * Stamp an entry checked WITHOUT touching its reply/Mention state — for a
+ * backfill fetch that failed (post gone, authorized-fetch instance, host down):
+ * whatever the row already says must never be clobbered by a non-answer.
+ */
+export const markTimelineEntryReplyChecked = async (user: string, id: string): Promise<void> => {
+  await query(user, `UPDATE timeline_entry SET reply_checked_at = NOW() WHERE id = $1`, [id])
+}
+
+/**
  * Remove a received post by its remote object id (on an inbound `Delete`), scoped
  * to the actor that authored it. The `actor_uri` guard is an authorization check:
  * an inbound `Delete` is only signed by *some* actor, so without it any actor

--- a/apps/backend/src/mcp/feed-tools.ts
+++ b/apps/backend/src/mcp/feed-tools.ts
@@ -29,12 +29,14 @@ import {
   deleteFeedPost,
   getActivityById,
   getFeedPostById,
+  getTimelineEntryById,
   listFeedFollowers,
   listFeedFollowing,
   updateFeedFollowingNotify,
   updateFeedPost,
 } from '../db/index.ts'
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
+import { fetchRemoteReplies } from '../services/activitypub/remote-replies.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { resolveChallengeShare } from '../services/challenge-share.ts'
@@ -48,6 +50,7 @@ import { serializeFollower } from '../services/followers.ts'
 import { serializeFollowing } from '../services/following.ts'
 import { getSettings } from '../services/settings.ts'
 import { getTimelinePage } from '../services/timeline.ts'
+import { withTimeout } from '../services/with-timeout.ts'
 import { errorResponse, jsonResponse, type McpServer } from './helpers.ts'
 
 /** Map the `status` filter to the follower-list DB options. */
@@ -257,6 +260,21 @@ export const registerFeedTools = (server: McpServer, user: string, options: Feed
       const page = await getTimelinePage(user, limit, cursor, { origin: webHost })
       retroEnrichTimeline?.(user)
       return jsonResponse(page)
+    },
+  )
+
+  server.tool(
+    'get_timeline_replies',
+    "Fetch a live, bounded snapshot of the replies to one home-timeline post (by the entry's local `id`) from its origin server. `partial: true` means the fetch budget ran out before the thread did.",
+    { id: z.string().uuid() },
+    async ({ id }) => {
+      const entry = await getTimelineEntryById(user, id)
+      if (entry == null) return jsonResponse({ error: 'Not found', success: false })
+      const result = await withTimeout(fetchRemoteReplies(entry.object_uri), 12_000).catch(() => ({
+        partial: true,
+        replies: [],
+      }))
+      return jsonResponse({ ...result, success: true })
     },
   )
 

--- a/apps/backend/src/routes/feed-router.ts
+++ b/apps/backend/src/routes/feed-router.ts
@@ -24,6 +24,7 @@ import {
   shareChallengeBodySchema,
   type TimelineQuery,
   timelineQuerySchema,
+  type TimelineRepliesResponse,
   type TimelineResponse,
   type UpdateArticleBody,
   updateArticleBodySchema,
@@ -42,9 +43,11 @@ import {
   deleteFeedPost,
   getActivityById,
   getFeedPostById,
+  getTimelineEntryById,
   updateFeedPost,
 } from '../db/index.ts'
 import { isPubliclyVisible } from '../services/activitypub/object.ts'
+import { fetchRemoteReplies } from '../services/activitypub/remote-replies.ts'
 import { buildArticleMarkdown, renderableArticleBlocks } from '../services/article-export.ts'
 import { buildArticleContent, mergeArticleContent } from '../services/article.ts'
 import { resolveChallengeShare } from '../services/challenge-share.ts'
@@ -56,6 +59,7 @@ import {
 } from '../services/feed.ts'
 import { getSettings } from '../services/settings.ts'
 import { getTimelinePage } from '../services/timeline.ts'
+import { withTimeout } from '../services/with-timeout.ts'
 import { type AnyMiddleware, type TypedRouter, typedRouter } from '../typed-router.ts'
 import { validateBody, validateQuery } from '../validation.ts'
 
@@ -85,6 +89,12 @@ export interface FeedDeliver {
   /** Federate a challenge-share edit as an `Update`. */
   updatedChallenge: (user: string, post: FeedPostRecord) => void
 }
+
+/** RFC 4122 canonical form — timeline entry ids are UUIDs. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Total budget for one reply-thread snapshot (object + collection + authors). */
+const REPLIES_TIMEOUT_MS = 12_000
 
 export const createFeedRouter = (
   authMiddleware: AnyMiddleware,
@@ -172,6 +182,31 @@ export const createFeedRouter = (
       })
       retroEnrichTimeline?.(user)
       res.json({ entries, next_cursor, success: true })
+    },
+  )
+
+  // Live snapshot of a timeline post's remote reply thread (#1060). Nothing is
+  // stored; `no-store` because the origin's thread changes under us. Bounded
+  // fetch budget inside, plus a hard timeout so a slow origin can't pin the
+  // request.
+  router.get<{ id: string }, TimelineRepliesResponse>(
+    '/timeline/:id/replies',
+    authMiddleware,
+    async (req, res) => {
+      const user = req.user!
+      if (!UUID_RE.test(req.params.id)) {
+        return res.status(404).json({ error: 'Not found', partial: false, replies: [], success: false })
+      }
+      const entry = await getTimelineEntryById(user, req.params.id)
+      if (entry == null) {
+        return res.status(404).json({ error: 'Not found', partial: false, replies: [], success: false })
+      }
+      const { partial, replies } = await withTimeout(
+        fetchRemoteReplies(entry.object_uri),
+        REPLIES_TIMEOUT_MS,
+      ).catch(() => ({ partial: true, replies: [] }))
+      res.setHeader('Cache-Control', 'no-store')
+      res.json({ partial, replies, success: true })
     },
   )
 

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -162,6 +162,8 @@ export const tableCreationOrder = [
   'timeline_entry_enrich_attempted',
   'timeline_entry_enrich_attempts',
   'timeline_entry_reply',
+  'timeline_entry_mentions',
+  'timeline_entry_reply_checked',
   'timeline_entry_indexes',
   'timeline_entry_unenriched_indexes',
   'profile_avatar',

--- a/apps/backend/src/schema.ts
+++ b/apps/backend/src/schema.ts
@@ -164,6 +164,7 @@ export const tableCreationOrder = [
   'timeline_entry_reply',
   'timeline_entry_mentions',
   'timeline_entry_reply_checked',
+  'timeline_entry_reply_checked_backstamp',
   'timeline_entry_indexes',
   'timeline_entry_unenriched_indexes',
   'profile_avatar',

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -343,6 +343,18 @@ export const socialTables: Record<string, string> = {
   timeline_entry_reply: `
     ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS in_reply_to_uri TEXT
   `,
+  // Whether the post carries a Mention tag for the timeline owner (#1060) —
+  // mentioned posts stay visible and notify whatever the reply setting says.
+  timeline_entry_mentions: `
+    ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS mentions_me BOOLEAN NOT NULL DEFAULT false
+  `,
+  // Lazy backfill bookkeeping (#1060): entries ingested before reply tracking
+  // have NULL here; the read path re-fetches a few per read to learn their
+  // inReplyTo/Mention state, stamping this whatever the outcome. New ingests
+  // stamp it immediately (the Note itself carried the answer).
+  timeline_entry_reply_checked: `
+    ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS reply_checked_at TIMESTAMPTZ
+  `,
   // Timeline ordering / keyset pagination is by (published_at DESC, id DESC).
   timeline_entry_indexes: `
     CREATE INDEX IF NOT EXISTS idx_timeline_entry_published

--- a/apps/backend/src/schema/social.ts
+++ b/apps/backend/src/schema/social.ts
@@ -355,6 +355,13 @@ export const socialTables: Record<string, string> = {
   timeline_entry_reply_checked: `
     ALTER TABLE timeline_entry ADD COLUMN IF NOT EXISTS reply_checked_at TIMESTAMPTZ
   `,
+  // Rows that already carry a reply link (ingested between #1061 and this
+  // migration) are KNOWN-correct — stamp them so the backfill never re-fetches
+  // (and can never clobber) them. Idempotent: matches nothing after first run.
+  timeline_entry_reply_checked_backstamp: `
+    UPDATE timeline_entry SET reply_checked_at = NOW()
+    WHERE reply_checked_at IS NULL AND in_reply_to_uri IS NOT NULL
+  `,
   // Timeline ordering / keyset pagination is by (published_at DESC, id DESC).
   timeline_entry_indexes: `
     CREATE INDEX IF NOT EXISTS idx_timeline_entry_published

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -49,7 +49,6 @@ import {
   countFeedFollowers,
   countPublicFeedPosts,
   deleteTimelineEntryByUri,
-  type FeedFollowingRecord,
   getFeedFollowerByActor,
   getFeedFollowingByActor,
   getFeedPostById,
@@ -68,6 +67,7 @@ import {
 } from '../../db/index.ts'
 import { resolveFeedActivity } from '../feed.ts'
 import { buildProfileUrl } from '../share-urls.ts'
+import { ownObjectPrefix } from '../timeline.ts'
 import { extractActorPresentation } from './actor-presentation.ts'
 import {
   buildArticleNote,
@@ -82,7 +82,12 @@ import {
 import { toCryptoKeyPair } from './keys.ts'
 import { AS_PUBLIC, isPubliclyVisible } from './object.ts'
 import { capabilityTokenFrom, createAurbodaEnricher } from './timeline-enrich.ts'
-import { extractNoteImages, noteToTimelineInput } from './timeline-ingest.ts'
+import {
+  extractNoteImages,
+  noteMentionsActor,
+  noteToTimelineInput,
+  type TimelineAuthor,
+} from './timeline-ingest.ts'
 
 /** Posts per outbox page (cursor pagination). */
 const OUTBOX_PAGE_SIZE = 20
@@ -164,35 +169,93 @@ const recordInboundFollow = async (
 export const ingestNoteForRecipient = async (
   user: string,
   note: Note,
-  followee: FeedFollowingRecord,
+  author: TimelineAuthor,
   enrich: (objectUri: string, token?: string) => Promise<FeedStructuredPost | null>,
   onNewEntry?: (user: string) => void,
+  /** Web origin — enables Mention detection against the recipient's actor URI (#1060). */
+  origin?: string,
 ): Promise<void> => {
-  const input = noteToTimelineInput(note, followee)
+  const input = noteToTimelineInput(note, author)
   if (input == null) return
   // Capture the Note's image attachments (rendered chart / route map, or a
   // Mastodon photo) so the timeline can show them when there's no native chart.
   const images = await extractNoteImages(note)
+  // A Mention of the recipient keeps the post visible + notifying whatever the
+  // reply setting says (Mastodon-style involvement).
+  const mentionsMe =
+    origin == null ? false : await noteMentionsActor(note, `${origin.replace(/\/+$/, '')}/users/${user}`)
   // Best-effort: fetch the native structured payload if this is an Aurboda post
   // (null otherwise). A followers-only post authorizes the fetch with the same
   // capability token embedded in its delivered image URL. Stored on the entry so
   // the web can render a native chart in place of the image.
   const structured = await enrich(input.object_uri, capabilityTokenFrom(images))
-  const { inserted } = await upsertTimelineEntry(user, { ...input, images, structured })
+  const { inserted } = await upsertTimelineEntry(user, {
+    ...input,
+    images,
+    mentions_me: mentionsMe,
+    structured,
+  })
   if (inserted) onNewEntry?.(user)
 }
 
 /**
- * Ingest a `Create`/`Update` of a `Note` into the recipient's home timeline —
- * but ONLY if the sender is an *accepted* followee (so the timeline can't be
- * injected into by a stranger who delivers to our inbox). Resolves the recipient
- * and the cached followee row, then hands off to `ingestNoteForRecipient`.
+ * Ingest a `Create`/`Update` of a `Note` into the recipient's home timeline.
+ * Two admissible senders (anything else is dropped, so a stranger can't inject
+ * arbitrary posts into our timeline by delivering to the inbox):
+ *
+ * - an *accepted* followee — any of their Notes;
+ * - **any actor whose Note is a reply to one of the recipient's own, still
+ *   existing posts** (#1060) — the Mastodon-style mention interaction, so a
+ *   stranger's "replied to you" shows up (and notifies) like it would there.
+ *   The author snapshot comes from the signature-verified sender actor.
+ *
  * Best-effort: unresolvable objects and non-Notes are ignored, and a missing DB
  * never 500s (which would invite retries).
  */
+/**
+ * The stranger branch of {@link ingestFeedActivity}: admit a non-followee's
+ * Note only when the recipient is INVOLVED — it replies to one of their own,
+ * still existing posts, or Mentions them. The author snapshot comes from the
+ * signature-verified sender actor.
+ */
+const ingestStrangerInvolvement = async (
+  ctx: InboxContext<void>,
+  activity: Create | Update,
+  object: Note,
+  me: string,
+  origin: string,
+  enrich: (objectUri: string, token?: string) => Promise<FeedStructuredPost | null>,
+  onNewEntry?: (user: string) => void,
+): Promise<void> => {
+  if (activity.actorId == null) return
+  const target = object.replyTargetIds[0]?.href
+  const prefix = ownObjectPrefix(origin, me)
+  const postId = target?.startsWith(prefix) ? target.slice(prefix.length) : null
+  const isReplyToOwnPost =
+    postId != null && UUID_RE.test(postId) && (await getFeedPostById(me, postId)) != null
+  if (!isReplyToOwnPost) {
+    const myActor = `${origin.replace(/\/+$/, '')}/users/${me}`
+    if (!(await noteMentionsActor(object, myActor))) return
+  }
+  // Fedify verified the HTTP signature as `activity.actorId`; fetch that actor
+  // for the presentation snapshot (handle / name / avatar).
+  const sender = await activity.getActor(ctx)
+  if (sender?.id == null || sender.id.href !== activity.actorId.href) return
+  const presentation = await extractActorPresentation(sender)
+  await ingestNoteForRecipient(
+    me,
+    object,
+    { ...presentation, actor_uri: activity.actorId.href },
+    enrich,
+    onNewEntry,
+    origin,
+  )
+}
+
 const ingestFeedActivity = async (
   ctx: InboxContext<void>,
   activity: Create | Update,
+  origin: string,
   onNewEntry?: (user: string) => void,
   /** Best-effort fetch of the post's native Aurboda structured data (null if not an Aurboda post). */
   enrich: (objectUri: string, token?: string) => Promise<FeedStructuredPost | null> = async () => null,
@@ -206,10 +269,12 @@ const ingestFeedActivity = async (
   if (me == null || !isValidUsername(me) || activity.actorId == null) return
   try {
     const follow = await getFeedFollowingByActor(me, activity.actorId.href)
-    if (follow == null || !follow.accepted) return
     const object = await activity.getObject({ suppressError: true })
     if (!(object instanceof Note)) return
-    await ingestNoteForRecipient(me, object, follow, enrich, onNewEntry)
+    if (follow != null && follow.accepted) {
+      return await ingestNoteForRecipient(me, object, follow, enrich, onNewEntry, origin)
+    }
+    await ingestStrangerInvolvement(ctx, activity, object, me, origin, enrich, onNewEntry)
   } catch (error) {
     if (isMissingDatabase(error)) return
     throw error
@@ -341,9 +406,7 @@ export const createFeedFederation = (
   }))
 
   federation
-    .setActorDispatcher('/users/{identifier}', (ctx, identifier) =>
-      buildActorPerson(ctx, identifier, origin),
-    )
+    .setActorDispatcher('/users/{identifier}', (ctx, identifier) => buildActorPerson(ctx, identifier, origin))
     .setKeyPairsDispatcher(async (_ctx, identifier) => {
       if (!isValidUsername(identifier)) return []
       try {
@@ -430,10 +493,11 @@ export const createFeedFederation = (
     })
     // Create / Update of a Note from an actor we follow → ingest into our home
     // timeline. Update reuses the same upsert (keyed on the Note's object id), so
-    // an edit replaces the stored copy. Only *accepted* followees are ingested, so
-    // a stranger who somehow delivers here can't inject into the timeline.
-    .on(Create, (ctx, create) => ingestFeedActivity(ctx, create, onNewTimelineEntry, enrich))
-    .on(Update, (ctx, update) => ingestFeedActivity(ctx, update, onNewTimelineEntry, enrich))
+    // an edit replaces the stored copy. Accepted followees are ingested in full;
+    // the only stranger Note admitted is a reply to one of the recipient's own
+    // posts (see ingestFeedActivity).
+    .on(Create, (ctx, create) => ingestFeedActivity(ctx, create, origin, onNewTimelineEntry, enrich))
+    .on(Update, (ctx, update) => ingestFeedActivity(ctx, update, origin, onNewTimelineEntry, enrich))
     .on(Delete, async (ctx, del) => {
       // Delete of a post we received → drop it from the timeline. `del.objectId`
       // is the removed object's id (a Tombstone or bare id); we key on it, but

--- a/apps/backend/src/services/activitypub/federation.ts
+++ b/apps/backend/src/services/activitypub/federation.ts
@@ -237,6 +237,13 @@ const ingestStrangerInvolvement = async (
     const myActor = `${origin.replace(/\/+$/, '')}/users/${me}`
     if (!(await noteMentionsActor(object, myActor))) return
   }
+  // Require EXPLICIT attribution to the signing actor. `noteToTimelineInput`'s
+  // attribution check is conditional (a Note without `attributedTo` passes on
+  // host match alone) — written for accepted followees; for a stranger that
+  // would let anyone on a followee's host claim an existing entry's object_uri
+  // and overwrite it via the upsert. Every real implementation sets
+  // `attributedTo`, so requiring it costs nothing.
+  if (!object.attributionIds.some((uri) => uri.href === activity.actorId?.href)) return
   // Fedify verified the HTTP signature as `activity.actorId`; fetch that actor
   // for the presentation snapshot (handle / name / avatar).
   const sender = await activity.getActor(ctx)

--- a/apps/backend/src/services/activitypub/remote-replies.test.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest'
+
+import { fetchRemoteReplies, type RemoteRepliesDeps } from './remote-replies.ts'
+
+const POST = 'https://mastodon.example/notes/1'
+
+/** Deps serving a fixed URL → document map; anything else rejects (unreachable). */
+const depsFor = (docs: Record<string, unknown>): RemoteRepliesDeps & { calls: string[] } => {
+  const calls: string[] = []
+  return {
+    calls,
+    fetchJson: async (url) => {
+      calls.push(url)
+      if (url in docs) return docs[url]
+      throw new Error(`unreachable ${url}`)
+    },
+  }
+}
+
+const reply = (n: number, over: Record<string, unknown> = {}) => ({
+  attributedTo: `https://mastodon.example/users/u${n}`,
+  content: `<p>reply ${n}</p>`,
+  id: `https://mastodon.example/notes/r${n}`,
+  published: '2026-08-20T10:00:00Z',
+  type: 'Note',
+  url: `https://mastodon.example/@u${n}/r${n}`,
+  ...over,
+})
+
+const actor = (n: number) => ({
+  id: `https://mastodon.example/users/u${n}`,
+  name: `User ${n}`,
+  preferredUsername: `u${n}`,
+  type: 'Person',
+})
+
+describe('fetchRemoteReplies', () => {
+  test('walks an inline collection, sanitising content and resolving authors', async () => {
+    const deps = depsFor({
+      [POST]: { id: POST, replies: { items: [reply(1, { content: '<p>hi<script>x</script></p>' })] } },
+      'https://mastodon.example/users/u1': actor(1),
+    })
+    const { partial, replies } = await fetchRemoteReplies(POST, deps)
+    expect(partial).toBe(false)
+    expect(replies).toHaveLength(1)
+    expect(replies[0].content).not.toContain('<script>')
+    expect(replies[0].content).toContain('hi')
+    expect(replies[0].handle).toBe('@u1@mastodon.example')
+    expect(replies[0].display_name).toBe('User 1')
+    expect(replies[0].url).toBe('https://mastodon.example/@u1/r1')
+  })
+
+  test('follows `first` and `next` pages and fetches URI-referenced items', async () => {
+    const deps = depsFor({
+      [POST]: { id: POST, replies: `${POST}/replies` },
+      [`${POST}/replies`]: { first: `${POST}/replies?page=1`, type: 'Collection' },
+      [`${POST}/replies?page=1`]: {
+        items: ['https://mastodon.example/notes/r1'],
+        next: `${POST}/replies?page=2`,
+      },
+      [`${POST}/replies?page=2`]: { items: [reply(2)] },
+      'https://mastodon.example/notes/r1': reply(1),
+      'https://mastodon.example/users/u1': actor(1),
+      'https://mastodon.example/users/u2': actor(2),
+    })
+    const { partial, replies } = await fetchRemoteReplies(POST, deps)
+    expect(partial).toBe(false)
+    expect(replies.map((r) => r.url)).toEqual([
+      'https://mastodon.example/@u1/r1',
+      'https://mastodon.example/@u2/r2',
+    ])
+  })
+
+  test('memoises author lookups and skips items without content', async () => {
+    const deps = depsFor({
+      [POST]: {
+        id: POST,
+        replies: { items: [reply(1), reply(1, { id: 'x', url: 'x' }), { type: 'Note' }] },
+      },
+      'https://mastodon.example/users/u1': actor(1),
+    })
+    const { replies } = await fetchRemoteReplies(POST, deps)
+    expect(replies).toHaveLength(2)
+    expect(deps.calls.filter((u) => u === 'https://mastodon.example/users/u1')).toHaveLength(1)
+  })
+
+  test('caps at the reply budget and reports partial', async () => {
+    const items = Array.from({ length: 30 }, (_, i) => reply(i))
+    const deps = depsFor({
+      [POST]: { id: POST, replies: { items } },
+      ...Object.fromEntries(items.map((_, i) => [`https://mastodon.example/users/u${i}`, actor(i)])),
+    })
+    const { partial, replies } = await fetchRemoteReplies(POST, deps)
+    expect(replies.length).toBeLessThanOrEqual(20)
+    expect(partial).toBe(true)
+  })
+
+  test('an unreachable origin yields an empty, non-throwing result', async () => {
+    const { partial, replies } = await fetchRemoteReplies(POST, depsFor({}))
+    expect(replies).toEqual([])
+    expect(partial).toBe(false)
+  })
+})

--- a/apps/backend/src/services/activitypub/remote-replies.test.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.test.ts
@@ -114,6 +114,15 @@ describe('fetchRemoteReplies', () => {
     expect(replies.map((r) => r.url)).toEqual([null, 'https://mastodon.example/@u2/r2'])
   })
 
+  test('drops an unparseable published timestamp (the web feeds it to date-fns)', async () => {
+    const deps = depsFor({
+      [POST]: { id: POST, replies: { items: [reply(1, { published: 'whenever' })] } },
+      'https://mastodon.example/users/u1': actor(1),
+    })
+    const { replies } = await fetchRemoteReplies(POST, deps)
+    expect(replies[0].published_at).toBeNull()
+  })
+
   test('an unreachable origin yields an empty, non-throwing result', async () => {
     const { partial, replies } = await fetchRemoteReplies(POST, depsFor({}))
     expect(replies).toEqual([])

--- a/apps/backend/src/services/activitypub/remote-replies.test.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.test.ts
@@ -95,6 +95,25 @@ describe('fetchRemoteReplies', () => {
     expect(partial).toBe(true)
   })
 
+  test('drops a non-http(s) url instead of handing the web a javascript: href', async () => {
+    const deps = depsFor({
+      [POST]: {
+        id: POST,
+        replies: {
+          items: [
+            // eslint-disable-next-line no-script-url
+            reply(1, { id: 'not a url', url: 'javascript:alert(1)' }),
+            reply(2),
+          ],
+        },
+      },
+      'https://mastodon.example/users/u1': actor(1),
+      'https://mastodon.example/users/u2': actor(2),
+    })
+    const { replies } = await fetchRemoteReplies(POST, deps)
+    expect(replies.map((r) => r.url)).toEqual([null, 'https://mastodon.example/@u2/r2'])
+  })
+
   test('an unreachable origin yields an empty, non-throwing result', async () => {
     const { partial, replies } = await fetchRemoteReplies(POST, depsFor({}))
     expect(replies).toEqual([])

--- a/apps/backend/src/services/activitypub/remote-replies.test.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.test.ts
@@ -75,7 +75,13 @@ describe('fetchRemoteReplies', () => {
     const deps = depsFor({
       [POST]: {
         id: POST,
-        replies: { items: [reply(1), reply(1, { id: 'x', url: 'x' }), { type: 'Note' }] },
+        replies: {
+          items: [
+            reply(1),
+            reply(1, { id: 'https://mastodon.example/notes/r1b', url: 'https://mastodon.example/@u1/r1b' }),
+            { type: 'Note' },
+          ],
+        },
       },
       'https://mastodon.example/users/u1': actor(1),
     })
@@ -102,7 +108,7 @@ describe('fetchRemoteReplies', () => {
         replies: {
           items: [
             // eslint-disable-next-line no-script-url
-            reply(1, { id: 'not a url', url: 'javascript:alert(1)' }),
+            reply(1, { url: 'javascript:alert(1)' }),
             reply(2),
           ],
         },
@@ -112,6 +118,44 @@ describe('fetchRemoteReplies', () => {
     })
     const { replies } = await fetchRemoteReplies(POST, deps)
     expect(replies.map((r) => r.url)).toEqual([null, 'https://mastodon.example/@u2/r2'])
+  })
+
+  test('drops a reply whose attribution or id is outside the serving origin (byline forgery)', async () => {
+    const deps = depsFor({
+      [POST]: {
+        id: POST,
+        replies: {
+          items: [
+            // Inline item claiming a famous foreign identity: attribution host
+            // differs from the origin that served it → dropped.
+            reply(1, { attributedTo: 'https://mastodon.social/users/Gargron' }),
+            // Inline item forging BOTH id and attribution onto the foreign
+            // host: id host differs from the serving page's host → dropped.
+            reply(2, {
+              attributedTo: 'https://mastodon.social/users/Gargron',
+              id: 'https://mastodon.social/notes/999',
+            }),
+            // Honest same-origin reply survives.
+            reply(3),
+          ],
+        },
+      },
+      'https://mastodon.example/users/u3': actor(3),
+    })
+    const { replies } = await fetchRemoteReplies(POST, deps)
+    expect(replies.map((r) => r.handle)).toEqual(['@u3@mastodon.example'])
+  })
+
+  test('a URI item whose fetched document claims a different host is dropped', async () => {
+    const deps = depsFor({
+      [POST]: { id: POST, replies: { items: ['https://evil.example/notes/1'] } },
+      'https://evil.example/notes/1': reply(1, {
+        attributedTo: 'https://mastodon.social/users/Gargron',
+        id: 'https://mastodon.social/notes/999',
+      }),
+    })
+    const { replies } = await fetchRemoteReplies(POST, deps)
+    expect(replies).toEqual([])
   })
 
   test('drops an unparseable published timestamp (the web feeds it to date-fns)', async () => {

--- a/apps/backend/src/services/activitypub/remote-replies.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.ts
@@ -1,0 +1,185 @@
+/**
+ * Live fetch of a remote post's `replies` collection (#1060) — the "expand
+ * replies" feature on a timeline card. Nothing is stored: the origin owns the
+ * thread, we render a bounded snapshot of it on demand.
+ *
+ * Strictly best-effort and budgeted: at most {@link MAX_REPLIES} replies from at
+ * most {@link MAX_FETCHES} SSRF-guarded requests (collection pages, reply
+ * objects referenced by URI, and author actors — one lookup per unique author,
+ * memoised). Anything malformed is skipped, never thrown; the response's
+ * `partial` flag tells the client the budget ran out before the collection did.
+ *
+ * All reply HTML goes through `sanitizeRemoteHtml` before it leaves this module
+ * — the payload is as untrusted as inbox content.
+ */
+import type { TimelineReply } from '@aurboda/api-spec'
+
+import { safeFetchGet } from '../safe-fetch.ts'
+import { sanitizeRemoteHtml } from './timeline-ingest.ts'
+
+const MAX_REPLIES = 20
+const MAX_FETCHES = 15
+const AP_ACCEPT = 'application/activity+json, application/ld+json; q=0.9'
+
+export interface RemoteRepliesDeps {
+  /** Fetch + JSON-decode an ActivityPub URL (SSRF-guarded). */
+  fetchJson: (url: string) => Promise<unknown>
+}
+
+export const realRemoteRepliesDeps: RemoteRepliesDeps = {
+  fetchJson: async (url) =>
+    (await safeFetchGet(url, { headers: { Accept: AP_ACCEPT } })).data,
+}
+
+type JsonRecord = Record<string, unknown>
+
+const isRecord = (v: unknown): v is JsonRecord => typeof v === 'object' && v != null && !Array.isArray(v)
+
+/** An AS2 value that may be an id string or an embedded object with an `id`. */
+const idOf = (v: unknown): string | null =>
+  typeof v === 'string' ? v : isRecord(v) && typeof v.id === 'string' ? v.id : null
+
+/** Budgeted fetch bookkeeping shared across one `fetchRemoteReplies` call. */
+interface Budget {
+  fetches: number
+  exhausted: boolean
+}
+
+const budgetedFetch = async (
+  deps: RemoteRepliesDeps,
+  budget: Budget,
+  url: string,
+): Promise<unknown | null> => {
+  if (budget.fetches >= MAX_FETCHES) {
+    budget.exhausted = true
+    return null
+  }
+  budget.fetches++
+  try {
+    return await deps.fetchJson(url)
+  } catch {
+    return null
+  }
+}
+
+/** Resolve a value that is either an inline AS2 object or a URI to fetch. */
+const resolveObject = async (
+  deps: RemoteRepliesDeps,
+  budget: Budget,
+  v: unknown,
+): Promise<JsonRecord | null> => {
+  if (isRecord(v)) return v
+  if (typeof v === 'string') {
+    const fetched = await budgetedFetch(deps, budget, v)
+    return isRecord(fetched) ? fetched : null
+  }
+  return null
+}
+
+interface ReplyAuthor {
+  display_name: string | null
+  handle: string | null
+}
+
+/** Resolve a reply author's presentation, memoised per call across replies. */
+const resolveAuthor = async (
+  deps: RemoteRepliesDeps,
+  budget: Budget,
+  actorUri: string,
+  authors: Map<string, ReplyAuthor>,
+): Promise<ReplyAuthor> => {
+  const cached = authors.get(actorUri)
+  if (cached != null) return cached
+  const actor = await resolveObject(deps, budget, actorUri)
+  const username =
+    actor != null && typeof actor.preferredUsername === 'string' ? actor.preferredUsername : null
+  const author: ReplyAuthor = {
+    display_name: actor != null && typeof actor.name === 'string' ? actor.name : null,
+    handle: username == null ? null : `@${username}@${new URL(actorUri).host}`,
+  }
+  authors.set(actorUri, author)
+  return author
+}
+
+/** Map one reply object to the DTO, resolving its author (memoised) within budget. */
+const toReply = async (
+  deps: RemoteRepliesDeps,
+  budget: Budget,
+  obj: JsonRecord,
+  authors: Map<string, ReplyAuthor>,
+): Promise<TimelineReply | null> => {
+  const content = typeof obj.content === 'string' ? obj.content : null
+  if (content == null) return null
+  const actorUri = idOf(obj.attributedTo)
+  const author = actorUri == null ? null : await resolveAuthor(deps, budget, actorUri, authors)
+  return {
+    actor_uri: actorUri,
+    content: sanitizeRemoteHtml(content),
+    display_name: author?.display_name ?? null,
+    handle: author?.handle ?? null,
+    published_at: typeof obj.published === 'string' ? obj.published : null,
+    url: typeof obj.url === 'string' ? obj.url : (idOf(obj.id) ?? null),
+  }
+}
+
+/**
+ * Fetch up to {@link MAX_REPLIES} replies to the post at `objectUri`, oldest
+ * first as the origin orders them. `partial` is true when a budget (reply
+ * count, fetch count) ended the walk before the collection did.
+ */
+export const fetchRemoteReplies = async (
+  objectUri: string,
+  deps: RemoteRepliesDeps = realRemoteRepliesDeps,
+): Promise<{ partial: boolean; replies: TimelineReply[] }> => {
+  const budget: Budget = { exhausted: false, fetches: 0 }
+  const authors = new Map<string, { display_name: string | null; handle: string | null }>()
+  const replies: TimelineReply[] = []
+
+  const post = await budgetedFetch(deps, budget, objectUri)
+  if (!isRecord(post)) return { partial: budget.exhausted, replies }
+
+  let page = await resolveFirstPage(deps, budget, post)
+  while (page != null && replies.length < MAX_REPLIES) {
+    await collectPageReplies(deps, budget, page, authors, replies)
+    if (replies.length >= MAX_REPLIES || page.next == null) break
+    page = await resolveObject(deps, budget, page.next)
+  }
+  const partial = budget.exhausted || replies.length >= MAX_REPLIES
+  return { partial, replies }
+}
+
+/**
+ * The collection's first item-bearing page: `replies` is an inline Collection
+ * or a URI, whose items may sit directly on it or behind a `first` page.
+ */
+const resolveFirstPage = async (
+  deps: RemoteRepliesDeps,
+  budget: Budget,
+  post: JsonRecord,
+): Promise<JsonRecord | null> => {
+  const collection = await resolveObject(deps, budget, post.replies)
+  if (collection == null) return null
+  const hasItems = collection.items != null || collection.orderedItems != null
+  return hasItems || collection.first == null
+    ? collection
+    : await resolveObject(deps, budget, collection.first)
+}
+
+/** Append this page's resolvable replies (inline or URI-referenced) up to the cap. */
+const collectPageReplies = async (
+  deps: RemoteRepliesDeps,
+  budget: Budget,
+  page: JsonRecord,
+  authors: Map<string, ReplyAuthor>,
+  replies: TimelineReply[],
+): Promise<void> => {
+  const rawItems = page.orderedItems ?? page.items
+  const items = Array.isArray(rawItems) ? rawItems : []
+  for (const item of items) {
+    if (replies.length >= MAX_REPLIES) return
+    const obj = await resolveObject(deps, budget, item)
+    if (obj == null) continue
+    const reply = await toReply(deps, budget, obj, authors)
+    if (reply != null) replies.push(reply)
+  }
+}

--- a/apps/backend/src/services/activitypub/remote-replies.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.ts
@@ -63,6 +63,42 @@ const httpsOnly = (raw: string | null): string | null => {
 const isoOrNull = (v: unknown): string | null =>
   typeof v === 'string' && !Number.isNaN(Date.parse(v)) ? v : null
 
+/** The URL's host, or null when it doesn't parse (remote-controlled input). */
+const hostOf = (raw: string): string | null => {
+  try {
+    return new URL(raw).host
+  } catch {
+    return null
+  }
+}
+
+/**
+ * A page (or collection) plus the host that actually SERVED it — the authority
+ * every inline item on it is held to. A URI-referenced page/item gets its own
+ * URI's host; an inline one inherits its parent's.
+ */
+interface PageCtx {
+  page: JsonRecord
+  host: string
+}
+
+/** Resolve an inline-or-URI page value into a page + its serving host. */
+const resolvePage = async (
+  deps: RemoteRepliesDeps,
+  budget: Budget,
+  v: unknown,
+  inlineHost: string,
+): Promise<PageCtx | null> => {
+  if (isRecord(v)) return { host: inlineHost, page: v }
+  if (typeof v === 'string') {
+    const host = hostOf(v)
+    if (host == null) return null
+    const fetched = await budgetedFetch(deps, budget, v)
+    return isRecord(fetched) ? { host, page: fetched } : null
+  }
+  return null
+}
+
 /** Budgeted fetch bookkeeping shared across one `fetchRemoteReplies` call. */
 interface Budget {
   fetches: number
@@ -117,14 +153,7 @@ const resolveAuthor = async (
   const actor = await resolveObject(deps, budget, actorUri)
   const username =
     actor != null && typeof actor.preferredUsername === 'string' ? actor.preferredUsername : null
-  // `attributedTo` is remote-controlled and may not be a URL at all — a throw
-  // here would collapse the whole thread to empty via the route's catch.
-  let host: string | null = null
-  try {
-    host = new URL(actorUri).host
-  } catch {
-    host = null
-  }
+  const host = hostOf(actorUri)
   const author: ReplyAuthor = {
     display_name: actor != null && typeof actor.name === 'string' ? actor.name : null,
     handle: username == null || host == null ? null : `@${username}@${host}`,
@@ -133,24 +162,36 @@ const resolveAuthor = async (
   return author
 }
 
-/** Map one reply object to the DTO, resolving its author (memoised) within budget. */
+/**
+ * Map one reply object to the DTO, resolving its author (memoised) within
+ * budget. `authorityHost` is the host that actually served the object (the
+ * page's host for inline items, the item URI's host for fetched ones): the
+ * object's own `id` AND its `attributedTo` must live on it, or the reply is
+ * dropped — otherwise a hostile origin could render arbitrary content under
+ * any fediverse identity (a byline-forgery/phishing primitive; sanitisation
+ * doesn't help against plain text under a forged handle).
+ */
 const toReply = async (
   deps: RemoteRepliesDeps,
   budget: Budget,
   obj: JsonRecord,
+  authorityHost: string,
   authors: Map<string, ReplyAuthor>,
 ): Promise<TimelineReply | null> => {
   const content = typeof obj.content === 'string' ? obj.content : null
   if (content == null) return null
+  const objId = idOf(obj.id)
+  if (objId == null || hostOf(objId) !== authorityHost) return null
   const actorUri = idOf(obj.attributedTo)
-  const author = actorUri == null ? null : await resolveAuthor(deps, budget, actorUri, authors)
+  if (actorUri == null || hostOf(actorUri) !== authorityHost) return null
+  const author = await resolveAuthor(deps, budget, actorUri, authors)
   return {
     actor_uri: actorUri,
     content: sanitizeRemoteHtml(content),
     display_name: author?.display_name ?? null,
     handle: author?.handle ?? null,
     published_at: isoOrNull(obj.published),
-    url: httpsOnly(typeof obj.url === 'string' ? obj.url : idOf(obj.id)),
+    url: httpsOnly(typeof obj.url === 'string' ? obj.url : objId),
   }
 }
 
@@ -167,14 +208,16 @@ export const fetchRemoteReplies = async (
   const authors = new Map<string, { display_name: string | null; handle: string | null }>()
   const replies: TimelineReply[] = []
 
+  const postHost = hostOf(objectUri)
+  if (postHost == null) return { partial: false, replies }
   const post = await budgetedFetch(deps, budget, objectUri)
   if (!isRecord(post)) return { partial: budget.exhausted, replies }
 
-  let page = await resolveFirstPage(deps, budget, post)
-  while (page != null && replies.length < MAX_REPLIES) {
-    await collectPageReplies(deps, budget, page, authors, replies)
-    if (replies.length >= MAX_REPLIES || page.next == null) break
-    page = await resolveObject(deps, budget, page.next)
+  let ctx = await resolveFirstPage(deps, budget, post, postHost)
+  while (ctx != null && replies.length < MAX_REPLIES) {
+    await collectPageReplies(deps, budget, ctx, authors, replies)
+    if (replies.length >= MAX_REPLIES || ctx.page.next == null) break
+    ctx = await resolvePage(deps, budget, ctx.page.next, ctx.host)
   }
   const partial = budget.exhausted || replies.length >= MAX_REPLIES
   return { partial, replies }
@@ -188,30 +231,32 @@ const resolveFirstPage = async (
   deps: RemoteRepliesDeps,
   budget: Budget,
   post: JsonRecord,
-): Promise<JsonRecord | null> => {
-  const collection = await resolveObject(deps, budget, post.replies)
+  postHost: string,
+): Promise<PageCtx | null> => {
+  const collection = await resolvePage(deps, budget, post.replies, postHost)
   if (collection == null) return null
-  const hasItems = collection.items != null || collection.orderedItems != null
-  return hasItems || collection.first == null
+  const hasItems = collection.page.items != null || collection.page.orderedItems != null
+  return hasItems || collection.page.first == null
     ? collection
-    : await resolveObject(deps, budget, collection.first)
+    : await resolvePage(deps, budget, collection.page.first, collection.host)
 }
 
 /** Append this page's resolvable replies (inline or URI-referenced) up to the cap. */
 const collectPageReplies = async (
   deps: RemoteRepliesDeps,
   budget: Budget,
-  page: JsonRecord,
+  ctx: PageCtx,
   authors: Map<string, ReplyAuthor>,
   replies: TimelineReply[],
 ): Promise<void> => {
-  const rawItems = page.orderedItems ?? page.items
+  const rawItems = ctx.page.orderedItems ?? ctx.page.items
   const items = Array.isArray(rawItems) ? rawItems : []
   for (const item of items) {
     if (replies.length >= MAX_REPLIES) return
-    const obj = await resolveObject(deps, budget, item)
-    if (obj == null) continue
-    const reply = await toReply(deps, budget, obj, authors)
+    // An inline item is held to the page's serving host; a URI item to its own.
+    const resolved = await resolvePage(deps, budget, item, ctx.host)
+    if (resolved == null) continue
+    const reply = await toReply(deps, budget, resolved.page, resolved.host, authors)
     if (reply != null) replies.push(reply)
   }
 }

--- a/apps/backend/src/services/activitypub/remote-replies.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.ts
@@ -39,6 +39,22 @@ const isRecord = (v: unknown): v is JsonRecord => typeof v === 'object' && v != 
 const idOf = (v: unknown): string | null =>
   typeof v === 'string' ? v : isRecord(v) && typeof v.id === 'string' ? v.id : null
 
+/**
+ * Keep a remote-supplied URL only when it is http(s). The web renders
+ * `TimelineReply.url` as an `href`, and a hostile origin (reachable by any
+ * stranger via mention-based ingestion) could otherwise hand us a
+ * `javascript:` URL that executes in the app origin on click.
+ */
+const httpsOnly = (raw: string | null): string | null => {
+  if (raw == null) return null
+  try {
+    const url = new URL(raw)
+    return url.protocol === 'https:' || url.protocol === 'http:' ? raw : null
+  } catch {
+    return null
+  }
+}
+
 /** Budgeted fetch bookkeeping shared across one `fetchRemoteReplies` call. */
 interface Budget {
   fetches: number
@@ -93,9 +109,17 @@ const resolveAuthor = async (
   const actor = await resolveObject(deps, budget, actorUri)
   const username =
     actor != null && typeof actor.preferredUsername === 'string' ? actor.preferredUsername : null
+  // `attributedTo` is remote-controlled and may not be a URL at all — a throw
+  // here would collapse the whole thread to empty via the route's catch.
+  let host: string | null = null
+  try {
+    host = new URL(actorUri).host
+  } catch {
+    host = null
+  }
   const author: ReplyAuthor = {
     display_name: actor != null && typeof actor.name === 'string' ? actor.name : null,
-    handle: username == null ? null : `@${username}@${new URL(actorUri).host}`,
+    handle: username == null || host == null ? null : `@${username}@${host}`,
   }
   authors.set(actorUri, author)
   return author
@@ -118,7 +142,7 @@ const toReply = async (
     display_name: author?.display_name ?? null,
     handle: author?.handle ?? null,
     published_at: typeof obj.published === 'string' ? obj.published : null,
-    url: typeof obj.url === 'string' ? obj.url : (idOf(obj.id) ?? null),
+    url: httpsOnly(typeof obj.url === 'string' ? obj.url : idOf(obj.id)),
   }
 }
 

--- a/apps/backend/src/services/activitypub/remote-replies.ts
+++ b/apps/backend/src/services/activitypub/remote-replies.ts
@@ -55,6 +55,14 @@ const httpsOnly = (raw: string | null): string | null => {
   }
 }
 
+/**
+ * Keep a remote-supplied timestamp only when it actually parses — the schema
+ * promises ISO 8601-or-null, and the web feeds it straight to date-fns, which
+ * throws on an Invalid Date (blanking the page on a hostile `published`).
+ */
+const isoOrNull = (v: unknown): string | null =>
+  typeof v === 'string' && !Number.isNaN(Date.parse(v)) ? v : null
+
 /** Budgeted fetch bookkeeping shared across one `fetchRemoteReplies` call. */
 interface Budget {
   fetches: number
@@ -141,7 +149,7 @@ const toReply = async (
     content: sanitizeRemoteHtml(content),
     display_name: author?.display_name ?? null,
     handle: author?.handle ?? null,
-    published_at: typeof obj.published === 'string' ? obj.published : null,
+    published_at: isoOrNull(obj.published),
     url: httpsOnly(typeof obj.url === 'string' ? obj.url : idOf(obj.id)),
   }
 }

--- a/apps/backend/src/services/activitypub/timeline-backfill.ts
+++ b/apps/backend/src/services/activitypub/timeline-backfill.ts
@@ -127,7 +127,8 @@ export const createTimelineBackfiller = (
   const deps: BackfillDeps = {
     fetchRecentNotes: (actorUri, limit) => fetchRecentOutboxNotes(federation, origin, actorUri, limit),
     getFollowee: getFeedFollowingByActor,
-    ingestNote: (user, note, followee) => ingestNoteForRecipient(user, note, followee, enrich),
+    ingestNote: (user, note, followee) =>
+      ingestNoteForRecipient(user, note, followee, enrich, undefined, origin),
   }
   return (user, actorUri) => {
     void withTimeout(backfillFolloweeTimeline(deps, user, actorUri), BACKFILL_TIMEOUT_MS)

--- a/apps/backend/src/services/activitypub/timeline-ingest.ts
+++ b/apps/backend/src/services/activitypub/timeline-ingest.ts
@@ -18,7 +18,7 @@
 import type { TimelineImage } from '@aurboda/api-spec'
 import type { Note } from '@fedify/fedify/vocab'
 
-import { Document, Image, Link } from '@fedify/fedify/vocab'
+import { Document, Image, Link, Mention } from '@fedify/fedify/vocab'
 import sanitizeHtml from 'sanitize-html'
 
 import type { FeedFollowingRecord, TimelineEntryInput } from '../../db/index.ts'
@@ -80,9 +80,20 @@ export const sanitizeRemoteHtml = (html: string): string =>
  * the sender-scoped inbound `Delete`. The author's presentation (handle / name /
  * avatar) comes from the cached `feed_following` row (no extra network).
  */
+/** The author fields the timeline snapshot needs — a followee row, or a stranger-replier's fetched presentation. */
+export type TimelineAuthor = Pick<FeedFollowingRecord, 'actor_uri' | 'avatar_url' | 'display_name' | 'handle'>
+
+/** Whether the Note carries a `Mention` tag pointing at `actorUri` (#1060). */
+export const noteMentionsActor = async (note: Note, actorUri: string): Promise<boolean> => {
+  for await (const tag of note.getTags({ suppressError: true })) {
+    if (tag instanceof Mention && tag.href?.href === actorUri) return true
+  }
+  return false
+}
+
 export const noteToTimelineInput = (
   note: Note,
-  author: FeedFollowingRecord,
+  author: TimelineAuthor,
   now: number = Date.now(),
 ): TimelineEntryInput | null => {
   if (note.id == null || note.published == null) return null

--- a/apps/backend/src/services/timeline-retro-enrich.test.ts
+++ b/apps/backend/src/services/timeline-retro-enrich.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, test } from 'vitest'
 
 import type { UnenrichedTimelineEntry } from '../db/index.ts'
 
-import { type RetroEnrichDeps, retroEnrichTimelineEntries } from './timeline-retro-enrich.ts'
+import {
+  backfillReplyLinks,
+  parseReplyInfo,
+  type RetroEnrichDeps,
+  retroEnrichTimelineEntries,
+} from './timeline-retro-enrich.ts'
 
 const UUID = '11111111-2222-4333-8444-555555555555'
 
@@ -119,5 +124,62 @@ describe('retroEnrichTimelineEntries', () => {
     // instead (retryable until the cap); 'fine' was stored.
     expect(saved).toEqual(['fine'])
     expect(transient).toEqual(['flaky:3'])
+  })
+})
+
+describe('parseReplyInfo', () => {
+  const ME = 'https://aurboda.example/users/me'
+
+  test('reads a string inReplyTo and a Mention tag pointing at me', () => {
+    const doc = {
+      inReplyTo: 'https://mastodon.example/notes/1',
+      tag: [{ href: ME, type: 'Mention' }],
+    }
+    expect(parseReplyInfo(doc, ME)).toEqual({
+      in_reply_to_uri: 'https://mastodon.example/notes/1',
+      mentions_me: true,
+    })
+  })
+
+  test('reads an object-form inReplyTo, a single non-array tag, and foreign mentions', () => {
+    const doc = {
+      inReplyTo: { id: 'https://mastodon.example/notes/2', type: 'Note' },
+      tag: { href: 'https://elsewhere.example/users/other', type: 'Mention' },
+    }
+    expect(parseReplyInfo(doc, ME)).toEqual({
+      in_reply_to_uri: 'https://mastodon.example/notes/2',
+      mentions_me: false,
+    })
+  })
+
+  test('a top-level post without tags yields nulls, as does a non-object doc', () => {
+    expect(parseReplyInfo({ content: '<p>hi</p>' }, ME)).toEqual({
+      in_reply_to_uri: null,
+      mentions_me: false,
+    })
+    expect(parseReplyInfo(null, ME)).toEqual({ in_reply_to_uri: null, mentions_me: false })
+  })
+})
+
+describe('backfillReplyLinks', () => {
+  test('stamps every candidate — reply info when fetched, nulls when unreachable', async () => {
+    const saved: [string, string | null, boolean][] = []
+    await backfillReplyLinks('u', 'https://aurboda.example/users/u', {
+      fetchObject: async (uri) =>
+        uri === 'https://m.example/notes/reply'
+          ? { inReplyTo: 'https://m.example/notes/root', tag: [] }
+          : null,
+      listUnchecked: async () => [
+        { id: 'a', object_uri: 'https://m.example/notes/reply' },
+        { id: 'b', object_uri: 'https://m.example/notes/gone' },
+      ],
+      saveReplyInfo: async (_u, id, inReplyToUri, mentionsMe) => {
+        saved.push([id, inReplyToUri, mentionsMe])
+      },
+    })
+    expect(saved).toEqual([
+      ['a', 'https://m.example/notes/root', false],
+      ['b', null, false],
+    ])
   })
 })

--- a/apps/backend/src/services/timeline-retro-enrich.test.ts
+++ b/apps/backend/src/services/timeline-retro-enrich.test.ts
@@ -162,24 +162,33 @@ describe('parseReplyInfo', () => {
 })
 
 describe('backfillReplyLinks', () => {
-  test('stamps every candidate — reply info when fetched, nulls when unreachable', async () => {
+  test('saves fetched reply info; a failed or non-JSON fetch only stamps (never clobbers)', async () => {
     const saved: [string, string | null, boolean][] = []
+    const stamped: string[] = []
     await backfillReplyLinks('u', 'https://aurboda.example/users/u', {
-      fetchObject: async (uri) =>
-        uri === 'https://m.example/notes/reply'
-          ? { inReplyTo: 'https://m.example/notes/root', tag: [] }
-          : null,
+      fetchObject: async (uri) => {
+        if (uri === 'https://m.example/notes/reply') {
+          return { inReplyTo: 'https://m.example/notes/root', tag: [] }
+        }
+        if (uri === 'https://m.example/notes/html') return '<!doctype html>…'
+        return null
+      },
       listUnchecked: async () => [
         { id: 'a', object_uri: 'https://m.example/notes/reply' },
         { id: 'b', object_uri: 'https://m.example/notes/gone' },
+        { id: 'c', object_uri: 'https://m.example/notes/html' },
       ],
+      markChecked: async (_u, id) => {
+        stamped.push(id)
+      },
       saveReplyInfo: async (_u, id, inReplyToUri, mentionsMe) => {
         saved.push([id, inReplyToUri, mentionsMe])
       },
     })
-    expect(saved).toEqual([
-      ['a', 'https://m.example/notes/root', false],
-      ['b', null, false],
-    ])
+    // Only the real AS2 answer writes reply state; the 404 and the HTML body
+    // are non-answers — a row that already carried a correct in_reply_to_uri
+    // (ingested between #1061 and the backstamp migration) must keep it.
+    expect(saved).toEqual([['a', 'https://m.example/notes/root', false]])
+    expect(stamped).toEqual(['b', 'c'])
   })
 })

--- a/apps/backend/src/services/timeline-retro-enrich.ts
+++ b/apps/backend/src/services/timeline-retro-enrich.ts
@@ -86,3 +86,64 @@ export const retroEnrichTimelineEntries = async (
   }
   return enriched
 }
+
+/**
+ * Reply/Mention state parsed from a fetched AS2 object (#1060): the
+ * `inReplyTo` id and whether a `Mention` tag points at `myActorUri`. Exported
+ * pure for tests.
+ */
+export const parseReplyInfo = (
+  doc: unknown,
+  myActorUri: string,
+): { in_reply_to_uri: string | null; mentions_me: boolean } => {
+  if (typeof doc !== 'object' || doc == null || Array.isArray(doc)) {
+    return { in_reply_to_uri: null, mentions_me: false }
+  }
+  const rec = doc as Record<string, unknown>
+  const reply = rec.inReplyTo
+  const inReplyToUri =
+    typeof reply === 'string'
+      ? reply
+      : typeof reply === 'object' &&
+          reply != null &&
+          typeof (reply as Record<string, unknown>).id === 'string'
+        ? ((reply as Record<string, unknown>).id as string)
+        : null
+  const tags = Array.isArray(rec.tag) ? rec.tag : rec.tag == null ? [] : [rec.tag]
+  const mentionsMe = tags.some(
+    (t) =>
+      typeof t === 'object' &&
+      t != null &&
+      (t as Record<string, unknown>).type === 'Mention' &&
+      (t as Record<string, unknown>).href === myActorUri,
+  )
+  return { in_reply_to_uri: inReplyToUri, mentions_me: mentionsMe }
+}
+
+export interface ReplyBackfillDeps {
+  listUnchecked: (user: string, limit: number) => Promise<{ id: string; object_uri: string }[]>
+  saveReplyInfo: (user: string, id: string, inReplyToUri: string | null, mentionsMe: boolean) => Promise<void>
+  /** SSRF-guarded ActivityPub fetch of the object, or null on any failure. */
+  fetchObject: (objectUri: string) => Promise<unknown | null>
+}
+
+/**
+ * Backfill reply/Mention state for entries ingested before #1060 tracked it —
+ * so a legacy reply stops rendering as a top-level card once the setting hides
+ * replies. One attempt per entry (`reply_checked_at` stamps whatever the
+ * outcome — an unreachable object stays a plain card, which is what it already
+ * was), a small batch per timeline read, sequential like the enrichment pass.
+ */
+export const backfillReplyLinks = async (
+  user: string,
+  myActorUri: string,
+  deps: ReplyBackfillDeps,
+  batchSize: number = RETRO_BATCH_SIZE,
+): Promise<void> => {
+  const candidates = await deps.listUnchecked(user, batchSize)
+  for (const entry of candidates) {
+    const doc = await deps.fetchObject(entry.object_uri)
+    const info = parseReplyInfo(doc, myActorUri)
+    await deps.saveReplyInfo(user, entry.id, info.in_reply_to_uri, info.mentions_me)
+  }
+}

--- a/apps/backend/src/services/timeline-retro-enrich.ts
+++ b/apps/backend/src/services/timeline-retro-enrich.ts
@@ -123,6 +123,8 @@ export const parseReplyInfo = (
 export interface ReplyBackfillDeps {
   listUnchecked: (user: string, limit: number) => Promise<{ id: string; object_uri: string }[]>
   saveReplyInfo: (user: string, id: string, inReplyToUri: string | null, mentionsMe: boolean) => Promise<void>
+  /** Stamp checked WITHOUT touching the stored reply state (failed fetch). */
+  markChecked: (user: string, id: string) => Promise<void>
   /** SSRF-guarded ActivityPub fetch of the object, or null on any failure. */
   fetchObject: (objectUri: string) => Promise<unknown | null>
 }
@@ -130,9 +132,11 @@ export interface ReplyBackfillDeps {
 /**
  * Backfill reply/Mention state for entries ingested before #1060 tracked it —
  * so a legacy reply stops rendering as a top-level card once the setting hides
- * replies. One attempt per entry (`reply_checked_at` stamps whatever the
- * outcome — an unreachable object stays a plain card, which is what it already
- * was), a small batch per timeline read, sequential like the enrichment pass.
+ * replies. One attempt per entry, a small batch per timeline read, sequential
+ * like the enrichment pass. A fetch that yields no usable AS2 object (post
+ * gone, authorized-fetch instance rejecting our unsigned GET, host down, HTML
+ * body) only STAMPS the entry — a non-answer must never overwrite whatever
+ * reply state the row already carries.
  */
 export const backfillReplyLinks = async (
   user: string,
@@ -143,6 +147,10 @@ export const backfillReplyLinks = async (
   const candidates = await deps.listUnchecked(user, batchSize)
   for (const entry of candidates) {
     const doc = await deps.fetchObject(entry.object_uri)
+    if (typeof doc !== 'object' || doc == null) {
+      await deps.markChecked(user, entry.id)
+      continue
+    }
     const info = parseReplyInfo(doc, myActorUri)
     await deps.saveReplyInfo(user, entry.id, info.in_reply_to_uri, info.mentions_me)
   }

--- a/apps/backend/src/services/timeline.test.ts
+++ b/apps/backend/src/services/timeline.test.ts
@@ -13,6 +13,7 @@ const record = (over: Partial<TimelineEntryRecord> = {}): TimelineEntryRecord =>
   id: '00000000-0000-0000-0000-000000000001',
   images: null,
   in_reply_to_uri: null,
+  mentions_me: false,
   object_uri: 'https://remote.example/notes/1',
   published_at: new Date('2026-07-01T08:00:00.000Z'),
   received_at: new Date('2026-07-01T08:00:05.000Z'),

--- a/apps/backend/src/services/timeline.ts
+++ b/apps/backend/src/services/timeline.ts
@@ -38,6 +38,7 @@ export const serializeTimelineEntry = (
         in_reply_to_mine: ownObjectPrefix != null && record.in_reply_to_uri.startsWith(ownObjectPrefix),
         in_reply_to_uri: record.in_reply_to_uri,
       }),
+  ...(record.mentions_me ? { mentions_me: true } : {}),
   ...(record.images == null || record.images.length === 0 ? {} : { images: record.images }),
   object_uri: record.object_uri,
   published_at: record.published_at.toISOString(),

--- a/apps/web/src/pages/Feed/FeedPostCard.css
+++ b/apps/web/src/pages/Feed/FeedPostCard.css
@@ -210,3 +210,67 @@
     background: #1f2937;
   }
 }
+
+.feed-post-replies-toggle {
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.feed-post-replies-status {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.feed-post-replies {
+  margin-top: 0.5rem;
+  border-left: 2px solid #e5e7eb;
+  padding-left: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.feed-post-reply-author {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.feed-post-reply-author a {
+  color: inherit;
+}
+
+.feed-post-reply-content {
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.feed-post-reply-content p {
+  margin: 0.2rem 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .feed-post-replies {
+    border-left-color: #374151;
+  }
+
+  .feed-post-replies-toggle {
+    border-color: #4b5563;
+    color: #9ca3af;
+  }
+}
+
+.timeline-replies-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-bottom: 0.75rem;
+}

--- a/apps/web/src/pages/Feed/HomeTimeline.tsx
+++ b/apps/web/src/pages/Feed/HomeTimeline.tsx
@@ -9,11 +9,11 @@
 import type { TimelineEntry, TimelineResponse } from '@aurboda/api-spec'
 import type { InfiniteData } from '@tanstack/react-query'
 
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import { useState } from 'preact/hooks'
 
-import { fetchTimeline } from '../../state/api'
+import { fetchTimeline, fetchTimelineReplies, fetchUserSettings, updateUserSettings } from '../../state/api'
 import { ActorName } from './ActorName'
 import { timelineImageVisible } from './timeline-structured'
 import { TimelineStructured } from './TimelineStructured'
@@ -71,11 +71,13 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
               <time title={new Date(entry.published_at).toLocaleString()}>{when}</time>
             )}
           </span>
-          {entry.in_reply_to_uri != null && (
+          {entry.in_reply_to_uri != null ? (
             <span class="feed-post-reply-marker">
               ↩ {entry.in_reply_to_mine ? 'replied to you' : 'a reply'}
             </span>
-          )}
+          ) : entry.mentions_me ? (
+            <span class="feed-post-reply-marker">@ mentioned you</span>
+          ) : null}
         </div>
       </header>
 
@@ -106,7 +108,102 @@ function TimelineCard({ entry }: { entry: TimelineEntry }) {
             loading="lazy"
           />
         ))}
+
+      <TimelineReplies entryId={entry.id} />
     </article>
+  )
+}
+
+/**
+ * Expandable live snapshot of the post's remote reply thread — fetched from the
+ * origin only when the reader asks (a bounded, best-effort walk of the AS2
+ * `replies` collection; `partial` marks a thread longer than the budget).
+ */
+function TimelineReplies({ entryId }: { entryId: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const query = useQuery({
+    enabled: expanded,
+    queryFn: () => fetchTimelineReplies(entryId),
+    queryKey: ['feed', 'timeline', entryId, 'replies'],
+    retry: false,
+    staleTime: 60 * 1000,
+  })
+
+  if (!expanded) {
+    return (
+      <button type="button" class="feed-post-replies-toggle" onClick={() => setExpanded(true)}>
+        Show replies
+      </button>
+    )
+  }
+  if (query.isLoading) return <p class="feed-post-replies-status">Loading replies…</p>
+  if (query.isError || !query.data?.success) {
+    return <p class="feed-post-replies-status">Couldn't fetch replies from the origin.</p>
+  }
+  const { partial, replies } = query.data
+  return (
+    <div class="feed-post-replies">
+      {replies.length === 0 ? (
+        <p class="feed-post-replies-status">No replies found on the origin.</p>
+      ) : (
+        replies.map((reply, i) => (
+          <div key={reply.url ?? i} class="feed-post-reply">
+            <span class="feed-post-reply-author">
+              {reply.display_name ?? reply.handle ?? reply.actor_uri ?? 'unknown'}
+              {reply.handle && reply.display_name ? ` ${reply.handle}` : ''}
+              {reply.url && (
+                <>
+                  {' · '}
+                  <a href={reply.url} target="_blank" rel="noopener noreferrer nofollow">
+                    {reply.published_at
+                      ? formatDistanceToNow(new Date(reply.published_at), { addSuffix: true })
+                      : 'link'}
+                  </a>
+                </>
+              )}
+            </span>
+            {/* Sanitised server-side (remote-replies.ts) — safe to render. */}
+            <div class="feed-post-reply-content" dangerouslySetInnerHTML={{ __html: reply.content }} />
+          </div>
+        ))
+      )}
+      {partial && <p class="feed-post-replies-status">Thread may be longer — see the original post.</p>}
+    </div>
+  )
+}
+
+/**
+ * The `timeline_show_replies` setting, surfaced where the timeline actually is
+ * (it also lives on the Settings page). Saving invalidates the timeline query
+ * so the filter takes effect immediately.
+ */
+function ShowRepliesToggle() {
+  const queryClient = useQueryClient()
+  const settingsQuery = useQuery({
+    queryFn: fetchUserSettings,
+    queryKey: ['userSettings'],
+    staleTime: 60 * 1000,
+  })
+  const mutation = useMutation({
+    mutationFn: (show: boolean) => updateUserSettings({ timeline_show_replies: show }),
+    onSuccess: (result) => {
+      queryClient.setQueryData(['userSettings'], result)
+      void queryClient.invalidateQueries({ queryKey: ['feed', 'timeline'] })
+    },
+  })
+  const show = mutation.isPending
+    ? (mutation.variables ?? false)
+    : (settingsQuery.data?.timeline_show_replies ?? false)
+  return (
+    <label class="timeline-replies-toggle">
+      <input
+        type="checkbox"
+        checked={show}
+        disabled={settingsQuery.isLoading || mutation.isPending}
+        onChange={(e) => mutation.mutate((e.target as HTMLInputElement).checked)}
+      />
+      <span>Show replies to others (replies to you always show)</span>
+    </label>
   )
 }
 
@@ -157,6 +254,7 @@ export function HomeTimeline() {
   return (
     <section class="timeline-section">
       <h2 class="feed-section-title">Home timeline</h2>
+      <ShowRepliesToggle />
       {pending.length > 0 && (
         <button type="button" class="timeline-new-pill" onClick={reveal}>
           {pending.length} new post{pending.length === 1 ? '' : 's'}

--- a/apps/web/src/state/api/feed.ts
+++ b/apps/web/src/state/api/feed.ts
@@ -14,6 +14,7 @@ import type {
   ShareActivityBody,
   ShareChallengeBody,
   SharePreviewResponse,
+  TimelineRepliesResponse,
   TimelineResponse,
   UpdateArticleBody,
   UpdateFeedPostBody,
@@ -225,6 +226,18 @@ export const fetchTimeline = async (cursor?: string): Promise<TimelineResponse> 
     headers: authHeaders(),
     params: cursor ? { cursor } : {},
   })
+  return response.data
+}
+
+/**
+ * Fetch a live, bounded snapshot of one timeline post's remote reply thread.
+ * `partial: true` means the server's fetch budget ran out before the thread did.
+ */
+export const fetchTimelineReplies = async (entryId: string): Promise<TimelineRepliesResponse> => {
+  const response = await axios.get<TimelineRepliesResponse>(
+    `${API_URL}/feed/timeline/${encodeURIComponent(entryId)}/replies`,
+    { headers: authHeaders() },
+  )
   return response.data
 }
 

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -42,8 +42,9 @@ run fetches `/feed/following` and `/feed/timeline`, then the pure, unit-tested
 newer than a stored high-water mark (judged by `received_at` — when the server
 stored the post — since `published_at` arrives out of order after federation
 retries), from a followed actor whose server-side `notify_on_post` flag is on
-(toggled per-account on the web Feed page), and not a reply to someone else
-(a reply notifies only when it targets one of your own posts, #1060). The first
+(toggled per-account on the web Feed page), and not a reply to someone else —
+posts the user is **involved** in (a reply to their own post, a Mention of
+them) notify whoever wrote them (#1060). The first
 run only records the high-water mark, so enabling the feature doesn't dump the
 backlog. The user opts in with the **"Notify me about new posts"** switch on the
 Account screen, which requests `POST_NOTIFICATIONS` (Android 13+) and
@@ -51,6 +52,12 @@ schedules/cancels the worker; tapping a notification opens the Feed tab. When
 the toggle is on but Android's app-level notification permission is off (the
 worker would silently skip posting), the Account screen shows a warning with a
 button into the system notification settings, re-checked on every resume.
+On launch, `AutoEnablePostNotifications` reconciles the Feed page's
+per-account bells with the device: if any bell is on and the user never made
+an explicit on/off choice, it requests the permission and starts the poller —
+so an active bell can't silently mean nothing. An explicit "off" is never
+overridden, and a denied request records "off" so the user isn't re-prompted
+every launch.
 
 ## Embedded web views
 

--- a/docs/features/feed.md
+++ b/docs/features/feed.md
@@ -222,15 +222,27 @@ bell in the web Following panel (or the `set_following_notify` MCP tool / `PATCH
 /feed/following/:id`). It controls whether the Android app raises a notification for that
 actor's new home-timeline posts; muting is preserved across a re-follow.
 
-**Replies** (#1060): ingest stores a received Note's `inReplyTo` id as
-`timeline_entry.in_reply_to_uri`. The timeline exposes it (plus `in_reply_to_mine`, true when
-the target is one of the reader's own posts) and filters by the **`timeline_show_replies`**
-user setting: off (the default) hides followed actors' replies to *other* people from the
-home timeline — replies to your own posts always show, marked "replied to you" on the card.
-The Android notifier follows the same involvement rule: new top-level posts notify, replies
-only when they target one of your posts. Entries also expose **`received_at`** (when this
-instance stored the post) — the notifier's high-water mark, since `published_at` can arrive
-out of order after federation retries.
+**Replies and mentions** (#1060): ingest stores a received Note's `inReplyTo` id as
+`timeline_entry.in_reply_to_uri` and whether it carries a `Mention` of the timeline owner as
+`mentions_me`. The timeline exposes both (plus `in_reply_to_mine`, true when the reply target
+is one of the reader's own posts) and filters by the **`timeline_show_replies`** user setting
+(toggle on the Feed page and in Settings): off (the default) hides followed actors' replies
+to *other* people — posts the reader is **involved** in (replies to their own posts, Mentions
+of them) always show, marked on the card. The inbox admits an involvement Note **from any
+actor**, not only followees (a stranger's reply to your post, or a post mentioning you, is
+the Mastodon-style interaction; the author snapshot comes from the signature-verified sender)
+— everything else from non-followees is still dropped. The Android notifier follows the same
+rule: top-level posts notify per the per-follow bell, involvement notifies regardless of who
+wrote it. Entries also expose **`received_at`** (when this instance stored the post) — the
+notifier's high-water mark, since `published_at` can arrive out of order after federation
+retries. Entries ingested before this shipped are **lazily backfilled**: each timeline read
+re-fetches a few unchecked objects (SSRF-guarded) and stamps their reply/Mention state.
+
+**Expanding a thread**: `GET /feed/timeline/:id/replies` (and the MCP `get_timeline_replies`
+tool) fetches a live, bounded snapshot of the post's remote `replies` collection — at most 20
+replies from at most 15 SSRF-guarded requests within a 12s budget, HTML sanitised
+server-side; `partial: true` marks a thread longer than the budget. Nothing is stored — the
+web's "Show replies" button on each timeline card renders it on demand.
 
 The actor advertises a **following collection** (`/users/<username>/following`) listing only
 _accepted_ follows (a pending follow isn't a confirmed relationship yet). The followee's

--- a/packages/api-spec/src/schemas/feed.ts
+++ b/packages/api-spec/src/schemas/feed.ts
@@ -652,6 +652,10 @@ export const timelineEntrySchema = z
     in_reply_to_uri: z.string().nullable().optional().meta({
       description: 'The `inReplyTo` object id when this post is a reply, else absent/null',
     }),
+    mentions_me: z.boolean().optional().meta({
+      description:
+        'True when the post carries a Mention of you — such posts always show and notify regardless of the `timeline_show_replies` setting',
+    }),
     images: z.array(timelineImageSchema).optional().meta({
       description:
         'Image attachments (e.g. a rendered chart or route map), shown when the post carries no native structured chart.',
@@ -687,6 +691,33 @@ export const timelineQuerySchema = z
   .meta({ id: 'TimelineQuery' })
 
 export type TimelineQuery = z.infer<typeof timelineQuerySchema>
+
+/** One reply fetched live from a remote post's `replies` collection. */
+export const timelineReplySchema = z
+  .object({
+    actor_uri: z.string().nullable().meta({ description: "The reply author's actor URI, if declared" }),
+    content: z.string().meta({ description: 'The reply HTML (sanitised server-side; safe to render)' }),
+    display_name: z.string().nullable().meta({ description: "The author's display name, if resolved" }),
+    handle: z.string().nullable().meta({ description: "The author's `@user@host` handle, if resolved" }),
+    published_at: iso8601DateTimeSchema.nullable().meta({ description: 'When the reply was published' }),
+    url: z.string().nullable().meta({ description: 'Link to the reply on its origin' }),
+  })
+  .meta({ id: 'TimelineReply' })
+
+export type TimelineReply = z.infer<typeof timelineReplySchema>
+
+/** Replies fetched live from the remote post behind one timeline entry. */
+export const timelineRepliesResponseSchema = baseResponseSchema
+  .extend({
+    partial: z.boolean().meta({
+      description:
+        'True when the fetch hit its budget (count/time) before exhausting the collection — more replies may exist on the origin',
+    }),
+    replies: z.array(timelineReplySchema).meta({ description: 'The fetched replies, oldest first' }),
+  })
+  .meta({ id: 'TimelineRepliesResponse' })
+
+export type TimelineRepliesResponse = z.infer<typeof timelineRepliesResponseSchema>
 
 /** A page of the home timeline, newest first, with an opaque cursor for the next page. */
 export const timelineResponseSchema = baseResponseSchema


### PR DESCRIPTION
Round 2 on #1060, from Fredrik's field feedback (with screenshots) + his follow-up question "are mentions of me from strangers also dropped?" (they were):

## Why the timeline was still full of replies
Entries ingested **before** #1061 have no `in_reply_to_uri` — the reply link was discarded at ingest — so the filter can't see them. Timeline reads now **lazily backfill** a few unchecked legacy entries per read (AP re-fetch of the object, one attempt, stamped via new `reply_checked_at`; fresh ingests stamp immediately). His timeline converges clean over a few page loads.

## Where the toggle is
`timeline_show_replies` now also sits **on the Feed page** next to the Home timeline (it stays in Settings too). Saving invalidates the timeline query so it applies immediately.

## Involvement: mentions + strangers
The inbox previously dropped every Note from a non-followee — including replies to your own posts and posts mentioning you. Now a non-followee's Note is admitted **iff you're involved**: it replies to one of your own (still existing) posts, or carries a `Mention` of your actor (new `mentions_me` column/field; author snapshot from the signature-verified sender). Involved posts always show (marked "replied to you" / "mentioned you") and always notify — regardless of the reply setting or the per-follow bells. Everything else from strangers is still dropped.

## Expand replies
`GET /feed/timeline/:id/replies` + MCP `get_timeline_replies`: a live, bounded snapshot of the post's remote AS2 `replies` collection — ≤20 replies from ≤15 SSRF-guarded fetches in a 12s budget, authors resolved + memoised, HTML sanitised server-side, nothing stored, `partial` flag when the thread outruns the budget. Web timeline cards get a **Show replies** button rendering it inline.

## Bells can't lie anymore
On launch, `AutoEnablePostNotifications` reconciles the Feed page's per-account 🔔 bells with the device: any bell on + no explicit on/off choice ever made → request `POST_NOTIFICATIONS` and start the poller. An explicit "off" is never overridden; a denial records "off" (no re-prompt loop) and the Account screen's existing blocked-warning takes over.

Tests: 5 new remote-replies unit tests (page walk, URI items, budget/partial, sanitisation, author memoisation), parseReplyInfo/backfill tests, db integration for the mentions filter + backfill helpers + `getTimelineEntryById`, Android involvement-predicate tests; whole-monorepo check green, activitypub suite 156/156, Android compile+unit green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwoP1SqJhHgHiEEoEQtUjT
