### PR TITLE
feat(web): challenges page groups by time status, ongoing front and centre

### DIFF
--- a/apps/web/src/pages/Challenges/challenge-status.test.ts
+++ b/apps/web/src/pages/Challenges/challenge-status.test.ts
@@ -15,9 +15,11 @@ import {
 // timezone consistently on both sides, so the tests are tz-independent.
 const iso = (local: string) => new Date(local).toISOString()
 
-// A one-week challenge: 1 Jun 00:00 (inclusive) .. 8 Jun 00:00 (exclusive).
+// A one-week challenge: 1 Jun 00:00 (inclusive) .. 8 Jun 00:00 (exclusive),
+// built in the runner's local timezone so viewer-local assertions hold anywhere.
 const start = iso('2026-06-01T00:00:00')
 const end = iso('2026-06-08T00:00:00')
+const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
 
 describe('challengeTimeStatus', () => {
   test('before the start instant is upcoming', () => {
@@ -53,33 +55,54 @@ describe('calendarDaysUntil', () => {
 
 describe('challengeTimePhrase', () => {
   test('upcoming: today / tomorrow / in N days', () => {
-    expect(challengeTimePhrase(start, end, new Date('2026-06-01T00:00:00') /* = start */)).not.toMatch(
-      /Starts/,
-    )
-    expect(challengeTimePhrase(start, end, new Date('2026-05-31T12:00:00'))).toBe('Starts tomorrow')
-    expect(challengeTimePhrase(start, end, new Date('2026-05-29T12:00:00'))).toBe('Starts in 3 days')
+    // At the start instant the challenge is already ongoing, so at a one-week
+    // horizon the phrase is the full remaining window.
+    expect(challengeTimePhrase(start, end, tz, new Date('2026-06-01T00:00:00'))).toBe('Ends in 6 days')
+    expect(challengeTimePhrase(start, end, tz, new Date('2026-05-31T12:00:00'))).toBe('Starts tomorrow')
+    expect(challengeTimePhrase(start, end, tz, new Date('2026-05-29T12:00:00'))).toBe('Starts in 3 days')
   })
 
   test('a challenge starting later today says Starts today', () => {
     const laterToday = iso('2026-05-31T18:00:00')
-    expect(challengeTimePhrase(laterToday, end, new Date('2026-05-31T12:00:00'))).toBe('Starts today')
+    expect(challengeTimePhrase(laterToday, end, tz, new Date('2026-05-31T12:00:00'))).toBe('Starts today')
   })
 
   test('ongoing: ends today / tomorrow / in N days (last included day, end exclusive)', () => {
     // Last included day is 7 Jun.
-    expect(challengeTimePhrase(start, end, new Date('2026-06-07T12:00:00'))).toBe('Ends today')
-    expect(challengeTimePhrase(start, end, new Date('2026-06-06T12:00:00'))).toBe('Ends tomorrow')
-    expect(challengeTimePhrase(start, end, new Date('2026-06-04T12:00:00'))).toBe('Ends in 3 days')
+    expect(challengeTimePhrase(start, end, tz, new Date('2026-06-07T12:00:00'))).toBe('Ends today')
+    expect(challengeTimePhrase(start, end, tz, new Date('2026-06-06T12:00:00'))).toBe('Ends tomorrow')
+    expect(challengeTimePhrase(start, end, tz, new Date('2026-06-04T12:00:00'))).toBe('Ends in 3 days')
   })
 
-  test('ended names the last included day', () => {
-    expect(challengeTimePhrase(start, end, new Date('2026-06-10T12:00:00'), 'en-GB')).toBe('Ended 7 Jun 2026')
+  test('ended names the last included day in the challenge timezone', () => {
+    // Hosted in Los Angeles: 1 Jun 00:00 PDT .. 8 Jun 00:00 PDT (exclusive).
+    expect(
+      challengeTimePhrase(
+        '2026-06-01T07:00:00Z',
+        '2026-06-08T07:00:00Z',
+        'America/Los_Angeles',
+        new Date('2026-06-20T12:00:00Z'),
+        'en-GB',
+      ),
+    ).toBe('Ended 7 Jun 2026')
   })
 })
 
 describe('challengeRangeLabel', () => {
   test('renders start through last included day', () => {
-    expect(challengeRangeLabel(start, end, 'en-GB')).toBe('1 Jun – 7 Jun 2026')
+    expect(challengeRangeLabel(start, end, tz, 'en-GB')).toBe('1 Jun – 7 Jun 2026')
+  })
+
+  test('renders in the challenge timezone, not the viewer timezone', () => {
+    // Hosted in Los Angeles, last day 7 Jun; end_ts is 8 Jun in UTC and most of
+    // Europe, but the host's window reads 1 Jun – 7 Jun.
+    expect(
+      challengeRangeLabel('2026-06-01T07:00:00Z', '2026-06-08T07:00:00Z', 'America/Los_Angeles', 'en-GB'),
+    ).toBe('1 Jun – 7 Jun 2026')
+  })
+
+  test('an invalid timezone falls back to the viewer timezone instead of throwing', () => {
+    expect(challengeRangeLabel(start, end, 'Not/A_Zone', 'en-GB')).toBe('1 Jun – 7 Jun 2026')
   })
 })
 

--- a/apps/web/src/pages/Challenges/challenge-status.test.ts
+++ b/apps/web/src/pages/Challenges/challenge-status.test.ts
@@ -1,0 +1,149 @@
+import type { Challenge, ChallengeParticipation } from '@aurboda/api-spec'
+
+import { describe, expect, test } from 'vitest'
+
+import {
+  calendarDaysUntil,
+  challengeItemKey,
+  challengeRangeLabel,
+  challengeTimePhrase,
+  challengeTimeStatus,
+  groupChallengeItems,
+} from './challenge-status'
+
+// Fixed instants; construction without timezone suffix uses the runner's local
+// timezone consistently on both sides, so the tests are tz-independent.
+const iso = (local: string) => new Date(local).toISOString()
+
+// A one-week challenge: 1 Jun 00:00 (inclusive) .. 8 Jun 00:00 (exclusive).
+const start = iso('2026-06-01T00:00:00')
+const end = iso('2026-06-08T00:00:00')
+
+describe('challengeTimeStatus', () => {
+  test('before the start instant is upcoming', () => {
+    expect(challengeTimeStatus(start, end, new Date('2026-05-31T23:59:59'))).toBe('upcoming')
+  })
+
+  test('the start instant itself is ongoing (inclusive)', () => {
+    expect(challengeTimeStatus(start, end, new Date(start))).toBe('ongoing')
+  })
+
+  test('just before the end instant is ongoing', () => {
+    expect(challengeTimeStatus(start, end, new Date('2026-06-07T23:59:59'))).toBe('ongoing')
+  })
+
+  test('the end instant itself is ended (exclusive)', () => {
+    expect(challengeTimeStatus(start, end, new Date(end))).toBe('ended')
+  })
+})
+
+describe('calendarDaysUntil', () => {
+  test('same local day is 0 regardless of clock time', () => {
+    expect(calendarDaysUntil(new Date('2026-06-03T23:00:00'), new Date('2026-06-03T01:00:00'))).toBe(0)
+  })
+
+  test('counts local calendar days, not 24h periods', () => {
+    expect(calendarDaysUntil(new Date('2026-06-04T01:00:00'), new Date('2026-06-03T23:00:00'))).toBe(1)
+  })
+
+  test('is negative for past days', () => {
+    expect(calendarDaysUntil(new Date('2026-06-01T12:00:00'), new Date('2026-06-03T12:00:00'))).toBe(-2)
+  })
+})
+
+describe('challengeTimePhrase', () => {
+  test('upcoming: today / tomorrow / in N days', () => {
+    expect(challengeTimePhrase(start, end, new Date('2026-06-01T00:00:00') /* = start */)).not.toMatch(
+      /Starts/,
+    )
+    expect(challengeTimePhrase(start, end, new Date('2026-05-31T12:00:00'))).toBe('Starts tomorrow')
+    expect(challengeTimePhrase(start, end, new Date('2026-05-29T12:00:00'))).toBe('Starts in 3 days')
+  })
+
+  test('a challenge starting later today says Starts today', () => {
+    const laterToday = iso('2026-05-31T18:00:00')
+    expect(challengeTimePhrase(laterToday, end, new Date('2026-05-31T12:00:00'))).toBe('Starts today')
+  })
+
+  test('ongoing: ends today / tomorrow / in N days (last included day, end exclusive)', () => {
+    // Last included day is 7 Jun.
+    expect(challengeTimePhrase(start, end, new Date('2026-06-07T12:00:00'))).toBe('Ends today')
+    expect(challengeTimePhrase(start, end, new Date('2026-06-06T12:00:00'))).toBe('Ends tomorrow')
+    expect(challengeTimePhrase(start, end, new Date('2026-06-04T12:00:00'))).toBe('Ends in 3 days')
+  })
+
+  test('ended names the last included day', () => {
+    expect(challengeTimePhrase(start, end, new Date('2026-06-10T12:00:00'), 'en-GB')).toBe('Ended 7 Jun 2026')
+  })
+})
+
+describe('challengeRangeLabel', () => {
+  test('renders start through last included day', () => {
+    expect(challengeRangeLabel(start, end, 'en-GB')).toBe('1 Jun – 7 Jun 2026')
+  })
+})
+
+describe('groupChallengeItems', () => {
+  const spec = {
+    aggregation: 'sum' as const,
+    bucket_size: 'auto' as const,
+    pattern: 'steps',
+    source_type: 'metric' as const,
+    unit: 'steps',
+  }
+
+  const hostedAt = (id: string, startLocal: string, endLocal: string): Challenge => ({
+    created_at: iso(startLocal),
+    end_ts: iso(endLocal),
+    id,
+    name: id,
+    share_url: `https://example.test/c/${id}`,
+    slug: id,
+    spec,
+    start_ts: iso(startLocal),
+    timezone: 'Europe/Stockholm',
+    updated_at: iso(startLocal),
+    visibility: 'unlisted',
+  })
+
+  const joinedAt = (id: string, startLocal: string, endLocal: string): ChallengeParticipation => ({
+    challenge_url: `https://example.test/c/${id}`,
+    created_at: iso(startLocal),
+    end_ts: iso(endLocal),
+    host_identity: 'host@example.test',
+    id,
+    name: id,
+    spec,
+    start_ts: iso(startLocal),
+    status: 'active',
+    timezone: 'Europe/Stockholm',
+  })
+
+  const now = new Date('2026-06-10T12:00:00')
+
+  test('splits hosted and joined by time status and sorts by relevance', () => {
+    const hosted = [
+      hostedAt('h-ended', '2026-05-01T00:00:00', '2026-05-08T00:00:00'),
+      hostedAt('h-ongoing-long', '2026-06-08T00:00:00', '2026-06-22T00:00:00'),
+    ]
+    const joined = [
+      joinedAt('j-ongoing-short', '2026-06-08T00:00:00', '2026-06-12T00:00:00'),
+      joinedAt('j-upcoming-near', '2026-06-15T00:00:00', '2026-06-22T00:00:00'),
+      joinedAt('j-upcoming-far', '2026-07-01T00:00:00', '2026-07-08T00:00:00'),
+      joinedAt('j-ended-recent', '2026-05-20T00:00:00', '2026-05-27T00:00:00'),
+    ]
+
+    const groups = groupChallengeItems(hosted, joined, now)
+
+    // Ongoing: ending soonest first.
+    expect(groups.ongoing.map(challengeItemKey)).toEqual(['joined-j-ongoing-short', 'hosted-h-ongoing-long'])
+    // Upcoming: starting soonest first.
+    expect(groups.upcoming.map(challengeItemKey)).toEqual(['joined-j-upcoming-near', 'joined-j-upcoming-far'])
+    // Ended: most recently ended first.
+    expect(groups.ended.map(challengeItemKey)).toEqual(['joined-j-ended-recent', 'hosted-h-ended'])
+  })
+
+  test('empty inputs give empty groups', () => {
+    expect(groupChallengeItems([], [], now)).toEqual({ ended: [], ongoing: [], upcoming: [] })
+  })
+})

--- a/apps/web/src/pages/Challenges/challenge-status.ts
+++ b/apps/web/src/pages/Challenges/challenge-status.ts
@@ -1,0 +1,87 @@
+/**
+ * Time-status helpers for the challenge list. A challenge window is
+ * `[start_ts, end_ts)` (end exclusive), so its last included moment is just
+ * before `end_ts` and the "last day" is the calendar day of `end_ts - 1ms`,
+ * rendered in the viewer's local timezone.
+ */
+
+import type { Challenge, ChallengeParticipation } from '@aurboda/api-spec'
+
+export type ChallengeTimeStatus = 'ended' | 'ongoing' | 'upcoming'
+
+export const challengeTimeStatus = (startTs: string, endTs: string, now: Date): ChallengeTimeStatus => {
+  const t = now.getTime()
+  if (t < new Date(startTs).getTime()) return 'upcoming'
+  if (t < new Date(endTs).getTime()) return 'ongoing'
+  return 'ended'
+}
+
+/** The last calendar moment included in the window (end_ts is exclusive). */
+export const lastIncludedMoment = (endTs: string): Date => new Date(new Date(endTs).getTime() - 1)
+
+/** Local midnight of a date — anchors calendar-day arithmetic, DST-safe via rounding. */
+const localMidnight = (d: Date): Date => new Date(d.getFullYear(), d.getMonth(), d.getDate())
+
+/** Whole calendar days from `now`'s local day to `target`'s local day (0 = same day). */
+export const calendarDaysUntil = (target: Date, now: Date): number =>
+  Math.round((localMidnight(target).getTime() - localMidnight(now).getTime()) / 86_400_000)
+
+const formatDay = (d: Date, locale?: string): string =>
+  d.toLocaleDateString(locale, { day: 'numeric', month: 'short', year: 'numeric' })
+
+/** "3 Jun – 9 Jun 2026" (last included day, not the exclusive end instant). */
+export const challengeRangeLabel = (startTs: string, endTs: string, locale?: string): string =>
+  `${new Date(startTs).toLocaleDateString(locale, { day: 'numeric', month: 'short' })} – ${formatDay(
+    lastIncludedMoment(endTs),
+    locale,
+  )}`
+
+const inDays = (days: number): string => (days === 1 ? 'tomorrow' : `in ${days} days`)
+
+/** Relative phrase for the row: "Ends today", "Starts tomorrow", "Ended 9 Jun 2026". */
+export const challengeTimePhrase = (startTs: string, endTs: string, now: Date, locale?: string): string => {
+  const status = challengeTimeStatus(startTs, endTs, now)
+  if (status === 'upcoming') {
+    const days = calendarDaysUntil(new Date(startTs), now)
+    return days === 0 ? 'Starts today' : `Starts ${inDays(days)}`
+  }
+  const lastDay = lastIncludedMoment(endTs)
+  if (status === 'ongoing') {
+    const days = calendarDaysUntil(lastDay, now)
+    return days <= 0 ? 'Ends today' : `Ends ${inDays(days)}`
+  }
+  return `Ended ${formatDay(lastDay, locale)}`
+}
+
+export type ChallengeItem =
+  | { kind: 'hosted'; challenge: Challenge }
+  | { kind: 'joined'; participation: ChallengeParticipation }
+
+const itemWindow = (item: ChallengeItem): { end_ts: string; start_ts: string } =>
+  item.kind === 'hosted' ? item.challenge : item.participation
+
+export const challengeItemKey = (item: ChallengeItem): string =>
+  item.kind === 'hosted' ? `hosted-${item.challenge.id}` : `joined-${item.participation.id}`
+
+/** Group hosted + joined challenges by time status, soonest-relevant first. */
+export const groupChallengeItems = (
+  hosted: Challenge[],
+  joined: ChallengeParticipation[],
+  now: Date,
+): Record<ChallengeTimeStatus, ChallengeItem[]> => {
+  const groups: Record<ChallengeTimeStatus, ChallengeItem[]> = { ended: [], ongoing: [], upcoming: [] }
+  const items: ChallengeItem[] = [
+    ...hosted.map((challenge) => ({ challenge, kind: 'hosted' as const })),
+    ...joined.map((participation) => ({ kind: 'joined' as const, participation })),
+  ]
+  for (const item of items) {
+    const { end_ts, start_ts } = itemWindow(item)
+    groups[challengeTimeStatus(start_ts, end_ts, now)].push(item)
+  }
+  const endMs = (i: ChallengeItem) => new Date(itemWindow(i).end_ts).getTime()
+  const startMs = (i: ChallengeItem) => new Date(itemWindow(i).start_ts).getTime()
+  groups.ongoing.sort((a, b) => endMs(a) - endMs(b)) // ending soonest first
+  groups.upcoming.sort((a, b) => startMs(a) - startMs(b)) // starting soonest first
+  groups.ended.sort((a, b) => endMs(b) - endMs(a)) // most recently ended first
+  return groups
+}

--- a/apps/web/src/pages/Challenges/challenge-status.ts
+++ b/apps/web/src/pages/Challenges/challenge-status.ts
@@ -26,20 +26,55 @@ const localMidnight = (d: Date): Date => new Date(d.getFullYear(), d.getMonth(),
 export const calendarDaysUntil = (target: Date, now: Date): number =>
   Math.round((localMidnight(target).getTime() - localMidnight(now).getTime()) / 86_400_000)
 
-const formatDay = (d: Date, locale?: string): string =>
-  d.toLocaleDateString(locale, { day: 'numeric', month: 'short', year: 'numeric' })
+/**
+ * Format in the challenge's IANA timezone so absolute dates read exactly as the
+ * host chose them (matching `formatDateInZone` on the challenge page), falling
+ * back to the viewer's timezone: the backend only validates `timezone` as a
+ * non-empty string, so a crafted value would otherwise throw `RangeError`.
+ */
+const formatInZone = (
+  d: Date,
+  timeZone: string,
+  opts: Intl.DateTimeFormatOptions,
+  locale?: string,
+): string => {
+  try {
+    return d.toLocaleDateString(locale, { ...opts, timeZone })
+  } catch {
+    return d.toLocaleDateString(locale, opts)
+  }
+}
 
-/** "3 Jun – 9 Jun 2026" (last included day, not the exclusive end instant). */
-export const challengeRangeLabel = (startTs: string, endTs: string, locale?: string): string =>
-  `${new Date(startTs).toLocaleDateString(locale, { day: 'numeric', month: 'short' })} – ${formatDay(
+const formatDay = (d: Date, timeZone: string, locale?: string): string =>
+  formatInZone(d, timeZone, { day: 'numeric', month: 'short', year: 'numeric' }, locale)
+
+/** "3 Jun – 9 Jun 2026" (last included day, not the exclusive end instant), in the challenge's timezone. */
+export const challengeRangeLabel = (
+  startTs: string,
+  endTs: string,
+  timeZone: string,
+  locale?: string,
+): string =>
+  `${formatInZone(new Date(startTs), timeZone, { day: 'numeric', month: 'short' }, locale)} – ${formatDay(
     lastIncludedMoment(endTs),
+    timeZone,
     locale,
   )}`
 
 const inDays = (days: number): string => (days === 1 ? 'tomorrow' : `in ${days} days`)
 
-/** Relative phrase for the row: "Ends today", "Starts tomorrow", "Ended 9 Jun 2026". */
-export const challengeTimePhrase = (startTs: string, endTs: string, now: Date, locale?: string): string => {
+/**
+ * Relative phrase for the row: "Ends today", "Starts tomorrow", "Ended 9 Jun 2026".
+ * Relative day counts are viewer-local (that's what "tomorrow" means to the
+ * reader); the absolute "Ended" date is in the challenge's timezone.
+ */
+export const challengeTimePhrase = (
+  startTs: string,
+  endTs: string,
+  timeZone: string,
+  now: Date,
+  locale?: string,
+): string => {
   const status = challengeTimeStatus(startTs, endTs, now)
   if (status === 'upcoming') {
     const days = calendarDaysUntil(new Date(startTs), now)
@@ -50,7 +85,7 @@ export const challengeTimePhrase = (startTs: string, endTs: string, now: Date, l
     const days = calendarDaysUntil(lastDay, now)
     return days <= 0 ? 'Ends today' : `Ends ${inDays(days)}`
   }
-  return `Ended ${formatDay(lastDay, locale)}`
+  return `Ended ${formatDay(lastDay, timeZone, locale)}`
 }
 
 export type ChallengeItem =

--- a/apps/web/src/pages/Challenges/index.tsx
+++ b/apps/web/src/pages/Challenges/index.tsx
@@ -1,9 +1,12 @@
 /**
  * Challenges - manage challenges you host and ones you've joined.
  *
- * Create a competition on a metric or activity type over a date range (public or
- * unlisted), copy its link, delete it; join a challenge by URL (local or on
- * another Aurboda instance). Federation happens server-side.
+ * The list is grouped by time status — Ongoing first and most prominent, then
+ * Upcoming, with Ended tucked into a collapsed section — so what needs
+ * attention right now is unmissable. Create a competition on a metric or
+ * activity type over a date range (public or unlisted), copy its link, delete
+ * it; join a challenge by URL (local or on another Aurboda instance).
+ * Federation happens server-side.
  */
 import type {
   Challenge,
@@ -28,6 +31,14 @@ import {
   listChallenges,
   listMyChallengeParticipations,
 } from '../../state/api'
+import {
+  type ChallengeItem,
+  challengeItemKey,
+  challengeRangeLabel,
+  challengeTimePhrase,
+  challengeTimeStatus,
+  groupChallengeItems,
+} from './challenge-status'
 import {
   browserTz,
   dateToEndIso,
@@ -194,7 +205,47 @@ function CreateChallengeForm({ onCreated }: { onCreated: () => void }) {
   )
 }
 
-function HostedRow({ challenge }: { challenge: Challenge }) {
+function RowMain({
+  endTs,
+  meta,
+  name,
+  now,
+  role,
+  startTs,
+  url,
+}: {
+  endTs: string
+  meta: string
+  name: string
+  now: Date
+  role: 'hosted' | 'joined'
+  startTs: string
+  url: string
+}) {
+  const status = challengeTimeStatus(startTs, endTs, now)
+  return (
+    <div class="challenge-row-main">
+      <div class="challenge-row-title">
+        <a class="challenge-row-name" href={url}>
+          {name}
+        </a>
+        <span class={`challenge-row-badge challenge-row-badge-${role}`}>
+          {role === 'hosted' ? 'Hosted by you' : 'Joined'}
+        </span>
+      </div>
+      <span class="challenge-row-meta">{meta}</span>
+      <span class="challenge-row-dates">
+        <span class={`challenge-row-phrase challenge-row-phrase-${status}`}>
+          {challengeTimePhrase(startTs, endTs, now)}
+        </span>
+        {' · '}
+        {challengeRangeLabel(startTs, endTs)}
+      </span>
+    </div>
+  )
+}
+
+function HostedRow({ challenge, now }: { challenge: Challenge; now: Date }) {
   const queryClient = useQueryClient()
   const [copied, setCopied] = useState(false)
   const [sharing, setSharing] = useState(false)
@@ -218,14 +269,15 @@ function HostedRow({ challenge }: { challenge: Challenge }) {
 
   return (
     <li class="challenge-row">
-      <div class="challenge-row-main">
-        <a class="challenge-row-name" href={challenge.share_url}>
-          {challenge.name}
-        </a>
-        <span class="challenge-row-meta">
-          {challenge.spec.pattern} · {challenge.spec.aggregation} · {challenge.visibility}
-        </span>
-      </div>
+      <RowMain
+        endTs={challenge.end_ts}
+        meta={`${challenge.spec.pattern} · ${challenge.spec.aggregation} · ${challenge.visibility}`}
+        name={challenge.name}
+        now={now}
+        role="hosted"
+        startTs={challenge.start_ts}
+        url={challenge.share_url}
+      />
       <div class="challenge-row-actions">
         <a class="btn-secondary" href={challenge.share_url}>
           View
@@ -252,7 +304,7 @@ function HostedRow({ challenge }: { challenge: Challenge }) {
   )
 }
 
-function JoinedRow({ participation }: { participation: ChallengeParticipation }) {
+function JoinedRow({ now, participation }: { now: Date; participation: ChallengeParticipation }) {
   const queryClient = useQueryClient()
   const [sharing, setSharing] = useState(false)
   const leave = useMutation({
@@ -263,12 +315,15 @@ function JoinedRow({ participation }: { participation: ChallengeParticipation })
 
   return (
     <li class="challenge-row">
-      <div class="challenge-row-main">
-        <a class="challenge-row-name" href={participation.challenge_url}>
-          {participation.name}
-        </a>
-        <span class="challenge-row-meta">{participation.host_identity}</span>
-      </div>
+      <RowMain
+        endTs={participation.end_ts}
+        meta={participation.host_identity}
+        name={participation.name}
+        now={now}
+        role="joined"
+        startTs={participation.start_ts}
+        url={participation.challenge_url}
+      />
       <div class="challenge-row-actions">
         <a class="btn-secondary" href={participation.challenge_url}>
           View
@@ -295,6 +350,20 @@ function JoinedRow({ participation }: { participation: ChallengeParticipation })
   )
 }
 
+function ChallengeRows({ items, now }: { items: ChallengeItem[]; now: Date }) {
+  return (
+    <ul class="challenge-list">
+      {items.map((item) =>
+        item.kind === 'hosted' ? (
+          <HostedRow key={challengeItemKey(item)} challenge={item.challenge} now={now} />
+        ) : (
+          <JoinedRow key={challengeItemKey(item)} now={now} participation={item.participation} />
+        ),
+      )}
+    </ul>
+  )
+}
+
 export function Challenges() {
   const queryClient = useQueryClient()
   const [joinUrl, setJoinUrl] = useState('')
@@ -317,6 +386,9 @@ export function Challenges() {
 
   const hosted = hostedQuery.data ?? []
   const joined = joinedQuery.data ?? []
+  const loading = hostedQuery.isLoading || joinedQuery.isLoading
+  const now = new Date()
+  const groups = groupChallengeItems(hosted, joined, now)
 
   return (
     <div class="challenges-page">
@@ -343,33 +415,38 @@ export function Challenges() {
         </button>
       </div>
 
-      <div class="challenges-columns">
-        <section>
-          <h2>Hosted by you</h2>
-          {hosted.length === 0 ? (
-            <p class="challenges-empty">You haven’t created any challenges yet.</p>
-          ) : (
-            <ul class="challenge-list">
-              {hosted.map((c) => (
-                <HostedRow key={c.id} challenge={c} />
-              ))}
-            </ul>
-          )}
-        </section>
+      <section class="challenge-group challenge-group-ongoing">
+        <h2>
+          <span class="challenge-ongoing-dot" aria-hidden="true" />
+          Ongoing
+          {groups.ongoing.length > 0 && <span class="challenge-group-count">{groups.ongoing.length}</span>}
+        </h2>
+        {groups.ongoing.length > 0 ? (
+          <ChallengeRows items={groups.ongoing} now={now} />
+        ) : (
+          <p class="challenges-empty">
+            {loading
+              ? 'Loading…'
+              : 'No ongoing challenges — join one by link above or create your own below.'}
+          </p>
+        )}
+      </section>
 
-        <section>
-          <h2>Joined</h2>
-          {joined.length === 0 ? (
-            <p class="challenges-empty">You haven’t joined any challenges yet.</p>
-          ) : (
-            <ul class="challenge-list">
-              {joined.map((p) => (
-                <JoinedRow key={p.id} participation={p} />
-              ))}
-            </ul>
-          )}
+      {groups.upcoming.length > 0 && (
+        <section class="challenge-group">
+          <h2>Upcoming</h2>
+          <ChallengeRows items={groups.upcoming} now={now} />
         </section>
-      </div>
+      )}
+
+      {groups.ended.length > 0 && (
+        <details class="challenge-group challenge-group-ended">
+          <summary>
+            <h2>Ended ({groups.ended.length})</h2>
+          </summary>
+          <ChallengeRows items={groups.ended} now={now} />
+        </details>
+      )}
 
       <CreateChallengeForm onCreated={() => queryClient.invalidateQueries({ queryKey: ['challenges'] })} />
     </div>

--- a/apps/web/src/pages/Challenges/index.tsx
+++ b/apps/web/src/pages/Challenges/index.tsx
@@ -212,6 +212,7 @@ function RowMain({
   now,
   role,
   startTs,
+  timezone,
   url,
 }: {
   endTs: string
@@ -220,6 +221,7 @@ function RowMain({
   now: Date
   role: 'hosted' | 'joined'
   startTs: string
+  timezone: string
   url: string
 }) {
   const status = challengeTimeStatus(startTs, endTs, now)
@@ -236,10 +238,10 @@ function RowMain({
       <span class="challenge-row-meta">{meta}</span>
       <span class="challenge-row-dates">
         <span class={`challenge-row-phrase challenge-row-phrase-${status}`}>
-          {challengeTimePhrase(startTs, endTs, now)}
+          {challengeTimePhrase(startTs, endTs, timezone, now)}
         </span>
         {' · '}
-        {challengeRangeLabel(startTs, endTs)}
+        {challengeRangeLabel(startTs, endTs, timezone)}
       </span>
     </div>
   )
@@ -276,6 +278,7 @@ function HostedRow({ challenge, now }: { challenge: Challenge; now: Date }) {
         now={now}
         role="hosted"
         startTs={challenge.start_ts}
+        timezone={challenge.timezone}
         url={challenge.share_url}
       />
       <div class="challenge-row-actions">
@@ -322,6 +325,7 @@ function JoinedRow({ now, participation }: { now: Date; participation: Challenge
         now={now}
         role="joined"
         startTs={participation.start_ts}
+        timezone={participation.timezone}
         url={participation.challenge_url}
       />
       <div class="challenge-row-actions">

--- a/apps/web/src/pages/Challenges/style.css
+++ b/apps/web/src/pages/Challenges/style.css
@@ -23,16 +23,52 @@
   font-size: 0.9rem;
 }
 
-.challenges-columns {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+/* Time-status groups: Ongoing (prominent) → Upcoming → Ended (collapsed) */
+.challenge-group {
+  margin-bottom: 1.5rem;
 }
 
-@media (max-width: 48em) {
-  .challenges-columns {
-    grid-template-columns: 1fr;
-  }
+.challenge-group h2 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.6rem;
+}
+
+.challenge-group-count {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #047857;
+  background: #d1fae5;
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+}
+
+.challenge-ongoing-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: #10b981;
+}
+
+.challenge-group-ongoing .challenge-row {
+  border-left: 3px solid #10b981;
+}
+
+.challenge-group-ended summary {
+  cursor: pointer;
+  list-style: revert;
+}
+
+.challenge-group-ended summary h2 {
+  display: inline-flex;
+  margin: 0 0 0.4rem;
+  color: #6b7280;
+  font-size: 1.1rem;
+}
+
+.challenge-group-ended .challenge-row {
+  opacity: 0.75;
 }
 
 .challenges-empty,
@@ -77,6 +113,48 @@
 .challenge-row-meta {
   font-size: 0.8rem;
   color: #6b7280;
+}
+
+.challenge-row-title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.challenge-row-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+  white-space: nowrap;
+}
+
+.challenge-row-badge-hosted {
+  color: #6d28d9;
+  background: #ede9fe;
+}
+
+.challenge-row-badge-joined {
+  color: #1d4ed8;
+  background: #dbeafe;
+}
+
+.challenge-row-dates {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.challenge-row-phrase {
+  font-weight: 600;
+}
+
+.challenge-row-phrase-ongoing {
+  color: #047857;
+}
+
+.challenge-row-phrase-upcoming {
+  color: #1d4ed8;
 }
 
 .challenge-row-actions {
@@ -199,7 +277,35 @@
   .challenges-empty,
   .challenge-view-meta,
   .public-muted,
-  .challenge-row-meta {
+  .challenge-row-meta,
+  .challenge-row-dates {
+    color: #9ca3af;
+  }
+
+  .challenge-group-count {
+    color: #6ee7b7;
+    background: #064e3b;
+  }
+
+  .challenge-row-badge-hosted {
+    color: #c4b5fd;
+    background: #3b2a63;
+  }
+
+  .challenge-row-badge-joined {
+    color: #93c5fd;
+    background: #1e3a5f;
+  }
+
+  .challenge-row-phrase-ongoing {
+    color: #34d399;
+  }
+
+  .challenge-row-phrase-upcoming {
+    color: #60a5fa;
+  }
+
+  .challenge-group-ended summary h2 {
     color: #9ca3af;
   }
 


### PR DESCRIPTION
## Summary

The /challenges list showed only hosted/joined columns with no dates, so nothing distinguished a challenge running right now from one that ended months ago. This PR makes ongoing challenges unmissable:

- **Ongoing** section first, with a green dot, count badge, and accent border on rows — sorted by ending soonest.
- **Upcoming** next (starting soonest first), rendered only when non-empty.
- **Ended** collapsed into a `<details>` section (most recently ended first), rows dimmed.
- Every row now shows its date range and a relative phrase — "Ends in 3 days", "Starts tomorrow", "Ended 7 Jun 2026" — plus a "Hosted by you"/"Joined" role badge (replacing the columns).

## Implementation

- Pure time-status/grouping helpers in `apps/web/src/pages/Challenges/challenge-status.ts` (`[start_ts, end_ts)` end-exclusive throughout; calendar-day arithmetic anchored on local midnights) with unit tests written first.
- `index.tsx` renders the groups; hosted/joined row actions unchanged.
- Dark-mode styles included for the new badges/phrases.
- Web-only: the Android app embeds this page, so parity is preserved.

## Testing

- `pnpm vitest run src/pages/Challenges/` — 25 tests pass.
- `pnpm check` green across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPd32AMQzUxZb233JGRKV